### PR TITLE
Remove timestamp from non-response events

### DIFF
--- a/src/Extensions/TaskEngine.bonsai
+++ b/src/Extensions/TaskEngine.bonsai
@@ -8,7 +8,6 @@
                  xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
                  xmlns:p3="clr-namespace:AllenNeuralDynamics.Core;assembly=AllenNeuralDynamics.Core"
                  xmlns:p4="clr-namespace:AllenNeuralDynamics.AindBehaviorServices.Distributions;assembly=AllenNeuralDynamics.AindBehaviorServices.Distributions"
-                 xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Workflow>
     <Nodes>
@@ -417,16 +416,13 @@
                             <p2:Value xsi:nil="true" />
                           </Combinator>
                         </Expression>
-                        <Expression xsi:type="SubscribeSubject">
-                          <Name>HarpTimestampSource</Name>
-                        </Expression>
                         <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:ObserveOn">
-                            <rx:Scheduler>ThreadPoolScheduler</rx:Scheduler>
+                          <Combinator xsi:type="DoubleProperty">
+                            <Value>NaN</Value>
                           </Combinator>
                         </Expression>
                         <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:WithLatestFrom" />
+                          <Combinator xsi:type="rx:Zip" />
                         </Expression>
                         <Expression xsi:type="SubscribeSubject">
                           <Name>ThisTrial</Name>
@@ -452,16 +448,13 @@
                             <p2:Value xsi:nil="true" />
                           </Combinator>
                         </Expression>
-                        <Expression xsi:type="SubscribeSubject">
-                          <Name>HarpTimestampSource</Name>
-                        </Expression>
                         <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:ObserveOn">
-                            <rx:Scheduler>ThreadPoolScheduler</rx:Scheduler>
+                          <Combinator xsi:type="DoubleProperty">
+                            <Value>NaN</Value>
                           </Combinator>
                         </Expression>
                         <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:WithLatestFrom" />
+                          <Combinator xsi:type="rx:Zip" />
                         </Expression>
                         <Expression xsi:type="SubscribeSubject">
                           <Name>IsRightLickEvent</Name>
@@ -485,9 +478,6 @@
                         <Expression xsi:type="Combinator">
                           <Combinator xsi:type="rx:Merge" />
                         </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="harp:CreateTimestamped" />
-                        </Expression>
                         <Expression xsi:type="rx:Sink">
                           <Name>CreateResponseSoftwaveEvent</Name>
                           <Workflow>
@@ -496,7 +486,7 @@
                                 <Name>Source1</Name>
                               </Expression>
                               <Expression xsi:type="MemberSelector">
-                                <Selector>Seconds,Value</Selector>
+                                <Selector>Item2,Item1</Selector>
                               </Expression>
                               <Expression xsi:type="ExternalizedMapping">
                                 <Property Name="EventName" />
@@ -558,33 +548,30 @@
                         <Edge From="1" To="2" Label="Source1" />
                         <Edge From="2" To="3" Label="Source1" />
                         <Edge From="3" To="4" Label="Source1" />
-                        <Edge From="4" To="7" Label="Source1" />
-                        <Edge From="5" To="6" Label="Source1" />
-                        <Edge From="6" To="7" Label="Source2" />
-                        <Edge From="7" To="22" Label="Source1" />
+                        <Edge From="4" To="6" Label="Source1" />
+                        <Edge From="5" To="6" Label="Source2" />
+                        <Edge From="6" To="20" Label="Source1" />
+                        <Edge From="7" To="8" Label="Source1" />
                         <Edge From="8" To="9" Label="Source1" />
                         <Edge From="9" To="10" Label="Source1" />
                         <Edge From="10" To="11" Label="Source1" />
                         <Edge From="11" To="12" Label="Source1" />
-                        <Edge From="12" To="13" Label="Source1" />
-                        <Edge From="13" To="16" Label="Source1" />
-                        <Edge From="14" To="15" Label="Source1" />
-                        <Edge From="15" To="16" Label="Source2" />
-                        <Edge From="16" To="22" Label="Source2" />
-                        <Edge From="17" To="18" Label="Source1" />
-                        <Edge From="17" To="20" Label="Source1" />
-                        <Edge From="18" To="19" Label="Source1" />
-                        <Edge From="19" To="21" Label="Source1" />
-                        <Edge From="20" To="21" Label="Source2" />
-                        <Edge From="21" To="22" Label="Source3" />
+                        <Edge From="12" To="14" Label="Source1" />
+                        <Edge From="13" To="14" Label="Source2" />
+                        <Edge From="14" To="20" Label="Source2" />
+                        <Edge From="15" To="16" Label="Source1" />
+                        <Edge From="15" To="18" Label="Source1" />
+                        <Edge From="16" To="17" Label="Source1" />
+                        <Edge From="17" To="19" Label="Source1" />
+                        <Edge From="18" To="19" Label="Source2" />
+                        <Edge From="19" To="20" Label="Source3" />
+                        <Edge From="20" To="21" Label="Source1" />
+                        <Edge From="21" To="22" Label="Source1" />
                         <Edge From="22" To="23" Label="Source1" />
-                        <Edge From="23" To="24" Label="Source1" />
                         <Edge From="24" To="25" Label="Source1" />
                         <Edge From="25" To="26" Label="Source1" />
                         <Edge From="27" To="28" Label="Source1" />
                         <Edge From="28" To="29" Label="Source1" />
-                        <Edge From="30" To="31" Label="Source1" />
-                        <Edge From="31" To="32" Label="Source1" />
                       </Edges>
                     </Workflow>
                   </Expression>
@@ -636,7 +623,7 @@
                           <Name>response</Name>
                         </Expression>
                         <Expression xsi:type="MemberSelector">
-                          <Selector>Value.HasValue</Selector>
+                          <Selector>Item1</Selector>
                         </Expression>
                         <Expression xsi:type="BitwiseNot" />
                         <Expression xsi:type="SubscribeSubject">
@@ -655,7 +642,7 @@
                                 <Name>Source1</Name>
                               </Expression>
                               <Expression xsi:type="MemberSelector">
-                                <Selector>Value</Selector>
+                                <Selector>Item1</Selector>
                               </Expression>
                               <Expression xsi:type="MemberSelector">
                                 <Selector>HasValue</Selector>
@@ -670,7 +657,7 @@
                           </Workflow>
                         </Expression>
                         <Expression xsi:type="MemberSelector">
-                          <Selector>Value.Value</Selector>
+                          <Selector>Item1.Value</Selector>
                         </Expression>
                         <Expression xsi:type="BitwiseNot" />
                         <Expression xsi:type="MulticastSubject">
@@ -778,7 +765,7 @@
                           <Name>response</Name>
                         </Expression>
                         <Expression xsi:type="MemberSelector">
-                          <Selector>Value</Selector>
+                          <Selector>Item1</Selector>
                         </Expression>
                         <Expression xsi:type="SubscribeSubject">
                           <Name>ThisTrial</Name>
@@ -1022,7 +1009,7 @@
                           </Workflow>
                         </Expression>
                         <Expression xsi:type="MemberSelector">
-                          <Selector>Response.Value.Value</Selector>
+                          <Selector>Response.Item1.Value</Selector>
                         </Expression>
                         <Expression xsi:type="MulticastSubject">
                           <Name>GiveRewardRight</Name>
@@ -1130,7 +1117,7 @@
                           <Selector>Response</Selector>
                         </Expression>
                         <Expression xsi:type="MemberSelector">
-                          <Selector>Value</Selector>
+                          <Selector>Item1.Value</Selector>
                         </Expression>
                         <Expression xsi:type="PropertyMapping">
                           <PropertyMappings>


### PR DESCRIPTION
This PR introduces a breaking change to the  `Response` software event:

- Response deadline and auto-response are now propagated with a timestamp set to "NaN"
- Since the `Bonsai.Harp.Timestamp<T>` constructor does not accept NaN as a timestamp, we introduce a breaking change by serializing as `Tuple<Nullable<bool>, double>` instead.

This should make the decision to only include hw-derived timestamps in this event more systematic and introduce less downstream analysis issues like in #118 

Closes #118 