### PR TITLE
fixes autowater in warmup curriculum

### DIFF
--- a/schema/aind_behavior_dynamic_foraging.json
+++ b/schema/aind_behavior_dynamic_foraging.json
@@ -1266,12 +1266,6 @@
           "title": "Extend Block On No Response",
           "type": "boolean"
         },
-        "min_block_reward": {
-          "default": 1,
-          "minimum": 0,
-          "title": "Minimal rewards in a block to switch",
-          "type": "integer"
-        },
         "kernel_size": {
           "default": 2,
           "description": "Kernel to evaluate choice fraction.",
@@ -1453,6 +1447,12 @@
             "evaluation_window": 20
           },
           "description": "Conditions to end trial generation."
+        },
+        "min_block_reward": {
+          "default": 1,
+          "minimum": 0,
+          "title": "Minimal rewards in a block to switch",
+          "type": "integer"
         }
       },
       "title": "CoupledWarmupTrialGeneratorSpec",

--- a/schema/coupled_baiting.json
+++ b/schema/coupled_baiting.json
@@ -84,7 +84,8 @@
                                         "max_choice_bias": 0.1,
                                         "min_response_rate": 0.8,
                                         "evaluation_window": 20
-                                    }
+                                    },
+                                    "min_block_reward": 1
                                 },
                                 {
                                     "type": "CoupledTrialGenerator",
@@ -163,7 +164,6 @@
                                         "min_consecutive_stable_trials": 5
                                     },
                                     "extend_block_on_no_response": true,
-                                    "min_block_reward": 0,
                                     "kernel_size": 2
                                 }
                             ]
@@ -268,7 +268,6 @@
                                 "min_consecutive_stable_trials": 5
                             },
                             "extend_block_on_no_response": true,
-                            "min_block_reward": 0,
                             "kernel_size": 2
                         }
                     },
@@ -371,7 +370,6 @@
                                 "min_consecutive_stable_trials": 5
                             },
                             "extend_block_on_no_response": true,
-                            "min_block_reward": 0,
                             "kernel_size": 2
                         }
                     },
@@ -474,7 +472,6 @@
                                 "min_consecutive_stable_trials": 5
                             },
                             "extend_block_on_no_response": true,
-                            "min_block_reward": 0,
                             "kernel_size": 2
                         }
                     },
@@ -581,7 +578,6 @@
                             },
                             "behavior_stability_parameters": null,
                             "extend_block_on_no_response": true,
-                            "min_block_reward": 0,
                             "kernel_size": 2
                         }
                     },
@@ -688,7 +684,6 @@
                             },
                             "behavior_stability_parameters": null,
                             "extend_block_on_no_response": true,
-                            "min_block_reward": 0,
                             "kernel_size": 2
                         }
                     },

--- a/schema/coupled_baiting.json
+++ b/schema/coupled_baiting.json
@@ -170,7 +170,7 @@
                         }
                     },
                     "version": "0.0.2",
-                    "stage_name": null
+                    "stage_name": "stage_1_warmup"
                 },
                 "graph": {
                     "nodes": {},
@@ -273,7 +273,7 @@
                         }
                     },
                     "version": "0.0.2",
-                    "stage_name": null
+                    "stage_name": "stage_1"
                 },
                 "graph": {
                     "nodes": {},
@@ -376,7 +376,7 @@
                         }
                     },
                     "version": "0.0.2",
-                    "stage_name": null
+                    "stage_name": "stage_2"
                 },
                 "graph": {
                     "nodes": {},
@@ -479,7 +479,7 @@
                         }
                     },
                     "version": "0.0.2",
-                    "stage_name": null
+                    "stage_name": "stage_3"
                 },
                 "graph": {
                     "nodes": {},
@@ -586,7 +586,7 @@
                         }
                     },
                     "version": "0.0.2",
-                    "stage_name": null
+                    "stage_name": "final"
                 },
                 "graph": {
                     "nodes": {},
@@ -693,7 +693,7 @@
                         }
                     },
                     "version": "0.0.2",
-                    "stage_name": null
+                    "stage_name": "graduated"
                 },
                 "graph": {
                     "nodes": {},

--- a/schema/coupled_baiting.json
+++ b/schema/coupled_baiting.json
@@ -55,8 +55,8 @@
                                         "scaling_parameters": null
                                     },
                                     "autowater_parameters": {
-                                        "min_ignored_trials": 3,
-                                        "min_unrewarded_trials": 3,
+                                        "min_ignored_trials": 0,
+                                        "min_unrewarded_trials": 0,
                                         "reward_fraction": 0.8
                                     },
                                     "bias_intervention_parameters": {
@@ -128,7 +128,7 @@
                                     "autowater_parameters": {
                                         "min_ignored_trials": 3,
                                         "min_unrewarded_trials": 3,
-                                        "reward_fraction": 0.8
+                                        "reward_fraction": 0.5
                                     },
                                     "bias_intervention_parameters": {
                                         "threshold": {
@@ -231,9 +231,9 @@
                                 "scaling_parameters": null
                             },
                             "autowater_parameters": {
-                                "min_ignored_trials": 3,
-                                "min_unrewarded_trials": 3,
-                                "reward_fraction": 0.8
+                                "min_ignored_trials": 5,
+                                "min_unrewarded_trials": 5,
+                                "reward_fraction": 0.5
                             },
                             "bias_intervention_parameters": {
                                 "threshold": {
@@ -334,9 +334,9 @@
                                 "scaling_parameters": null
                             },
                             "autowater_parameters": {
-                                "min_ignored_trials": 3,
-                                "min_unrewarded_trials": 3,
-                                "reward_fraction": 0.8
+                                "min_ignored_trials": 7,
+                                "min_unrewarded_trials": 7,
+                                "reward_fraction": 0.5
                             },
                             "bias_intervention_parameters": {
                                 "threshold": {
@@ -437,9 +437,9 @@
                                 "scaling_parameters": null
                             },
                             "autowater_parameters": {
-                                "min_ignored_trials": 3,
-                                "min_unrewarded_trials": 3,
-                                "reward_fraction": 0.8
+                                "min_ignored_trials": 10,
+                                "min_unrewarded_trials": 10,
+                                "reward_fraction": 0.5
                             },
                             "bias_intervention_parameters": {
                                 "threshold": {
@@ -539,11 +539,7 @@
                                 },
                                 "scaling_parameters": null
                             },
-                            "autowater_parameters": {
-                                "min_ignored_trials": 3,
-                                "min_unrewarded_trials": 3,
-                                "reward_fraction": 0.8
-                            },
+                            "autowater_parameters": null,
                             "bias_intervention_parameters": {
                                 "threshold": {
                                     "upper": 0.7,
@@ -650,11 +646,7 @@
                                 },
                                 "scaling_parameters": null
                             },
-                            "autowater_parameters": {
-                                "min_ignored_trials": 3,
-                                "min_unrewarded_trials": 3,
-                                "reward_fraction": 0.8
-                            },
+                            "autowater_parameters": null,
                             "bias_intervention_parameters": {
                                 "threshold": {
                                     "upper": 0.7,

--- a/schema/uncoupled.json
+++ b/schema/uncoupled.json
@@ -84,7 +84,8 @@
                                         "max_choice_bias": 0.1,
                                         "min_response_rate": 0.8,
                                         "evaluation_window": 20
-                                    }
+                                    },
+                                    "min_block_reward": 1
                                 },
                                 {
                                     "type": "CoupledTrialGenerator",
@@ -163,7 +164,6 @@
                                         "min_consecutive_stable_trials": 5
                                     },
                                     "extend_block_on_no_response": true,
-                                    "min_block_reward": 0,
                                     "kernel_size": 2
                                 }
                             ]
@@ -268,7 +268,6 @@
                                 "min_consecutive_stable_trials": 5
                             },
                             "extend_block_on_no_response": true,
-                            "min_block_reward": 0,
                             "kernel_size": 2
                         }
                     },
@@ -371,7 +370,6 @@
                                 "min_consecutive_stable_trials": 5
                             },
                             "extend_block_on_no_response": true,
-                            "min_block_reward": 0,
                             "kernel_size": 2
                         }
                     },

--- a/schema/uncoupled.json
+++ b/schema/uncoupled.json
@@ -55,9 +55,9 @@
                                         "scaling_parameters": null
                                     },
                                     "autowater_parameters": {
-                                        "min_ignored_trials": 3,
-                                        "min_unrewarded_trials": 3,
-                                        "reward_fraction": 0.5
+                                        "min_ignored_trials": 0,
+                                        "min_unrewarded_trials": 0,
+                                        "reward_fraction": 0.8
                                     },
                                     "bias_intervention_parameters": {
                                         "threshold": {

--- a/schema/uncoupled.json
+++ b/schema/uncoupled.json
@@ -170,7 +170,7 @@
                         }
                     },
                     "version": "0.0.2",
-                    "stage_name": null
+                    "stage_name": "stage_1_warmup"
                 },
                 "graph": {
                     "nodes": {},
@@ -273,7 +273,7 @@
                         }
                     },
                     "version": "0.0.2",
-                    "stage_name": null
+                    "stage_name": "stage_1"
                 },
                 "graph": {
                     "nodes": {},
@@ -376,7 +376,7 @@
                         }
                     },
                     "version": "0.0.2",
-                    "stage_name": null
+                    "stage_name": "stage_2"
                 },
                 "graph": {
                     "nodes": {},
@@ -465,7 +465,7 @@
                         }
                     },
                     "version": "0.0.2",
-                    "stage_name": null
+                    "stage_name": "stage_3"
                 },
                 "graph": {
                     "nodes": {},
@@ -550,7 +550,7 @@
                         }
                     },
                     "version": "0.0.2",
-                    "stage_name": null
+                    "stage_name": "final"
                 },
                 "graph": {
                     "nodes": {},
@@ -635,7 +635,7 @@
                         }
                     },
                     "version": "0.0.2",
-                    "stage_name": null
+                    "stage_name": "graduated"
                 },
                 "graph": {
                     "nodes": {},

--- a/schema/uncoupled_baiting.json
+++ b/schema/uncoupled_baiting.json
@@ -84,7 +84,8 @@
                                         "max_choice_bias": 0.1,
                                         "min_response_rate": 0.8,
                                         "evaluation_window": 20
-                                    }
+                                    },
+                                    "min_block_reward": 1
                                 },
                                 {
                                     "type": "CoupledTrialGenerator",
@@ -163,7 +164,6 @@
                                         "min_consecutive_stable_trials": 5
                                     },
                                     "extend_block_on_no_response": true,
-                                    "min_block_reward": 0,
                                     "kernel_size": 2
                                 }
                             ]
@@ -268,7 +268,6 @@
                                 "min_consecutive_stable_trials": 5
                             },
                             "extend_block_on_no_response": true,
-                            "min_block_reward": 0,
                             "kernel_size": 2
                         }
                     },
@@ -371,7 +370,6 @@
                                 "min_consecutive_stable_trials": 5
                             },
                             "extend_block_on_no_response": true,
-                            "min_block_reward": 0,
                             "kernel_size": 2
                         }
                     },

--- a/schema/uncoupled_baiting.json
+++ b/schema/uncoupled_baiting.json
@@ -170,7 +170,7 @@
                         }
                     },
                     "version": "0.0.2",
-                    "stage_name": null
+                    "stage_name": "stage_1_warmup"
                 },
                 "graph": {
                     "nodes": {},
@@ -273,7 +273,7 @@
                         }
                     },
                     "version": "0.0.2",
-                    "stage_name": null
+                    "stage_name": "stage_1"
                 },
                 "graph": {
                     "nodes": {},
@@ -376,7 +376,7 @@
                         }
                     },
                     "version": "0.0.2",
-                    "stage_name": null
+                    "stage_name": "stage_2"
                 },
                 "graph": {
                     "nodes": {},
@@ -465,7 +465,7 @@
                         }
                     },
                     "version": "0.0.2",
-                    "stage_name": null
+                    "stage_name": "stage_3"
                 },
                 "graph": {
                     "nodes": {},
@@ -550,7 +550,7 @@
                         }
                     },
                     "version": "0.0.2",
-                    "stage_name": null
+                    "stage_name": "final"
                 },
                 "graph": {
                     "nodes": {},
@@ -635,7 +635,7 @@
                         }
                     },
                     "version": "0.0.2",
-                    "stage_name": null
+                    "stage_name": "graduated"
                 },
                 "graph": {
                     "nodes": {},

--- a/schema/uncoupled_baiting.json
+++ b/schema/uncoupled_baiting.json
@@ -55,8 +55,8 @@
                                         "scaling_parameters": null
                                     },
                                     "autowater_parameters": {
-                                        "min_ignored_trials": 3,
-                                        "min_unrewarded_trials": 3,
+                                        "min_ignored_trials": 0,
+                                        "min_unrewarded_trials": 0,
                                         "reward_fraction": 0.8
                                     },
                                     "bias_intervention_parameters": {
@@ -128,7 +128,7 @@
                                     "autowater_parameters": {
                                         "min_ignored_trials": 3,
                                         "min_unrewarded_trials": 3,
-                                        "reward_fraction": 0.8
+                                        "reward_fraction": 0.5
                                     },
                                     "bias_intervention_parameters": {
                                         "threshold": {
@@ -231,9 +231,9 @@
                                 "scaling_parameters": null
                             },
                             "autowater_parameters": {
-                                "min_ignored_trials": 3,
-                                "min_unrewarded_trials": 3,
-                                "reward_fraction": 0.8
+                                "min_ignored_trials": 5,
+                                "min_unrewarded_trials": 5,
+                                "reward_fraction": 0.5
                             },
                             "bias_intervention_parameters": {
                                 "threshold": {
@@ -334,9 +334,9 @@
                                 "scaling_parameters": null
                             },
                             "autowater_parameters": {
-                                "min_ignored_trials": 3,
-                                "min_unrewarded_trials": 3,
-                                "reward_fraction": 0.8
+                                "min_ignored_trials": 7,
+                                "min_unrewarded_trials": 7,
+                                "reward_fraction": 0.5
                             },
                             "bias_intervention_parameters": {
                                 "threshold": {
@@ -434,9 +434,9 @@
                                 "scaling_parameters": null
                             },
                             "autowater_parameters": {
-                                "min_ignored_trials": 3,
-                                "min_unrewarded_trials": 3,
-                                "reward_fraction": 0.8
+                                "min_ignored_trials": 10,
+                                "min_unrewarded_trials": 10,
+                                "reward_fraction": 0.5
                             },
                             "bias_intervention_parameters": {
                                 "threshold": {
@@ -522,11 +522,7 @@
                                 "truncation_parameters": null,
                                 "scaling_parameters": null
                             },
-                            "autowater_parameters": {
-                                "min_ignored_trials": 3,
-                                "min_unrewarded_trials": 3,
-                                "reward_fraction": 0.8
-                            },
+                            "autowater_parameters": null,
                             "bias_intervention_parameters": {
                                 "threshold": {
                                     "upper": 0.7,
@@ -611,11 +607,7 @@
                                 "truncation_parameters": null,
                                 "scaling_parameters": null
                             },
-                            "autowater_parameters": {
-                                "min_ignored_trials": 3,
-                                "min_unrewarded_trials": 3,
-                                "reward_fraction": 0.8
-                            },
+                            "autowater_parameters": null,
                             "bias_intervention_parameters": {
                                 "threshold": {
                                     "upper": 0.7,

--- a/src/Extensions/AindBehaviorDynamicForaging.Generated.cs
+++ b/src/Extensions/AindBehaviorDynamicForaging.Generated.cs
@@ -2282,8 +2282,6 @@ namespace AindDynamicForagingDataSchema
     
         private bool _extendBlockOnNoResponse;
     
-        private int _minBlockReward;
-    
         private int _kernelSize;
     
         public CoupledTrialGeneratorSpec()
@@ -2300,7 +2298,6 @@ namespace AindDynamicForagingDataSchema
             _trialGenerationEndParameters = new CoupledTrialGenerationEndConditions();
             _behaviorStabilityParameters = new BehaviorStabilityParameters();
             _extendBlockOnNoResponse = true;
-            _minBlockReward = 1;
             _kernelSize = 2;
         }
     
@@ -2319,7 +2316,6 @@ namespace AindDynamicForagingDataSchema
             _trialGenerationEndParameters = other._trialGenerationEndParameters;
             _behaviorStabilityParameters = other._behaviorStabilityParameters;
             _extendBlockOnNoResponse = other._extendBlockOnNoResponse;
-            _minBlockReward = other._minBlockReward;
             _kernelSize = other._kernelSize;
         }
     
@@ -2541,19 +2537,6 @@ namespace AindDynamicForagingDataSchema
             }
         }
     
-        [Newtonsoft.Json.JsonPropertyAttribute("min_block_reward")]
-        public int MinBlockReward
-        {
-            get
-            {
-                return _minBlockReward;
-            }
-            set
-            {
-                _minBlockReward = value;
-            }
-        }
-    
         /// <summary>
         /// Kernel to evaluate choice fraction.
         /// </summary>
@@ -2599,7 +2582,6 @@ namespace AindDynamicForagingDataSchema
             stringBuilder.Append("TrialGenerationEndParameters = " + _trialGenerationEndParameters + ", ");
             stringBuilder.Append("BehaviorStabilityParameters = " + _behaviorStabilityParameters + ", ");
             stringBuilder.Append("ExtendBlockOnNoResponse = " + _extendBlockOnNoResponse + ", ");
-            stringBuilder.Append("MinBlockReward = " + _minBlockReward + ", ");
             stringBuilder.Append("KernelSize = " + _kernelSize);
             return true;
         }
@@ -2764,6 +2746,8 @@ namespace AindDynamicForagingDataSchema
     
         private CoupledWarmupTrialGenerationEndConditions _trialGenerationEndParameters;
     
+        private int _minBlockReward;
+    
         public CoupledWarmupTrialGeneratorSpec()
         {
             _quiescentDuration = new AllenNeuralDynamics.AindBehaviorServices.Distributions.Distribution();
@@ -2776,6 +2760,7 @@ namespace AindDynamicForagingDataSchema
             _isBaiting = true;
             _rewardProbabilityParameters = new RewardProbabilityParameters();
             _trialGenerationEndParameters = new CoupledWarmupTrialGenerationEndConditions();
+            _minBlockReward = 1;
         }
     
         protected CoupledWarmupTrialGeneratorSpec(CoupledWarmupTrialGeneratorSpec other) : 
@@ -2791,6 +2776,7 @@ namespace AindDynamicForagingDataSchema
             _isBaiting = other._isBaiting;
             _rewardProbabilityParameters = other._rewardProbabilityParameters;
             _trialGenerationEndParameters = other._trialGenerationEndParameters;
+            _minBlockReward = other._minBlockReward;
         }
     
         /// <summary>
@@ -2973,6 +2959,19 @@ namespace AindDynamicForagingDataSchema
             }
         }
     
+        [Newtonsoft.Json.JsonPropertyAttribute("min_block_reward")]
+        public int MinBlockReward
+        {
+            get
+            {
+                return _minBlockReward;
+            }
+            set
+            {
+                _minBlockReward = value;
+            }
+        }
+    
         public System.IObservable<CoupledWarmupTrialGeneratorSpec> Generate()
         {
             return System.Reactive.Linq.Observable.Defer(() => System.Reactive.Linq.Observable.Return(new CoupledWarmupTrialGeneratorSpec(this)));
@@ -2998,7 +2997,8 @@ namespace AindDynamicForagingDataSchema
             stringBuilder.Append("BiasInterventionParameters = " + _biasInterventionParameters + ", ");
             stringBuilder.Append("IsBaiting = " + _isBaiting + ", ");
             stringBuilder.Append("RewardProbabilityParameters = " + _rewardProbabilityParameters + ", ");
-            stringBuilder.Append("TrialGenerationEndParameters = " + _trialGenerationEndParameters);
+            stringBuilder.Append("TrialGenerationEndParameters = " + _trialGenerationEndParameters + ", ");
+            stringBuilder.Append("MinBlockReward = " + _minBlockReward);
             return true;
         }
     }

--- a/src/aind_behavior_dynamic_foraging/task_logic/trial_generators/coupled_trial_generators/coupled_trial_generator.py
+++ b/src/aind_behavior_dynamic_foraging/task_logic/trial_generators/coupled_trial_generators/coupled_trial_generator.py
@@ -74,8 +74,6 @@ class CoupledTrialGeneratorSpec(BaseCoupledTrialGeneratorSpec):
         description="Whether to extend the minimum block length by one trial when the animal does not respond.",
     )
 
-    min_block_reward: int = Field(default=1, ge=0, title="Minimal rewards in a block to switch")
-
     kernel_size: int = Field(default=2, description="Kernel to evaluate choice fraction.")
 
     def create_generator(self) -> "CoupledTrialGenerator":
@@ -290,13 +288,8 @@ class CoupledTrialGenerator(BaseCoupledTrialGenerator):
         )
         logger.debug("Behavior meets stability criteria: %s" % behavior_ok)
 
-        # has reward criteria been met?
-        reward_ok = self.reward_history.count(False) + self.reward_history.count(True) >= self.spec.min_block_reward
-        logger.debug("Reward criterion satisfied: %s" % reward_ok)
-
         # conditions to switch:
         #   - planned block length reached
-        #   - minimum reward requirement is reached
         #   - behavior is stable
 
-        return block_length_ok and reward_ok and behavior_ok
+        return block_length_ok and behavior_ok

--- a/src/aind_behavior_dynamic_foraging/task_logic/trial_generators/coupled_trial_generators/coupled_warmup_trial_generator.py
+++ b/src/aind_behavior_dynamic_foraging/task_logic/trial_generators/coupled_trial_generators/coupled_warmup_trial_generator.py
@@ -46,6 +46,8 @@ class CoupledWarmupTrialGeneratorSpec(BaseCoupledTrialGeneratorSpec):
         default=True, description="Whether uncollected rewards carry over to the next trial."
     )
 
+    min_block_reward: int = Field(default=1, ge=0, title="Minimal rewards in a block to switch")
+
     def create_generator(self) -> "CoupledWarmupTrialGenerator":
         return CoupledWarmupTrialGenerator(self)
 
@@ -90,12 +92,13 @@ class CoupledWarmupTrialGenerator(BaseCoupledTrialGenerator):
         )
         return False
 
-    def _is_block_switch_allowed(self) -> True:
+    def _is_block_switch_allowed(self) -> bool:
         """
-        Warmup switches block every update
+        Warmup switches when minimum reward.
 
         Returns:
-            True
+            bool indicating whether block can switch
         """
 
-        return True
+        reward_count = sum([outcome.is_rewarded for outcome in self.outcome_history])
+        return reward_count >= self.spec.min_block_reward

--- a/tests/trial_generators/test_coupled_trial_generator.py
+++ b/tests/trial_generators/test_coupled_trial_generator.py
@@ -173,7 +173,6 @@ class TestCoupledTrialGenerator(unittest.TestCase):
         self.generator.trials_in_block = 20
         self.generator.reward_history = [True] * 5
         self.generator.is_right_choice_history = [True] * 20
-        self.generator.spec.min_block_reward = 1
 
         result = self.generator._is_block_switch_allowed()
         self.assertTrue(result)
@@ -185,19 +184,6 @@ class TestCoupledTrialGenerator(unittest.TestCase):
         self.generator.reward_history = [True] * 5
         self.generator.is_right_choice_history = [True] * 10
         self.generator.trials_in_block = 10
-        self.generator.spec.min_block_reward = 1
-
-        result = self.generator._is_block_switch_allowed()
-        self.assertFalse(result)
-
-    def test_block_switch_reward_not_met(self):
-        self.generator.block.p_right_reward = 0.8
-        self.generator.block.p_left_reward = 0.2
-        self.generator.block.right_length = 20
-        self.generator.reward_history = []  # no rewards
-        self.generator.is_right_choice_history = [True] * 20
-        self.generator.trials_in_block = 20
-        self.generator.spec.min_block_reward = 5
 
         result = self.generator._is_block_switch_allowed()
         self.assertFalse(result)
@@ -209,7 +195,6 @@ class TestCoupledTrialGenerator(unittest.TestCase):
         self.generator.reward_history = [True] * 5
         self.generator.is_right_choice_history = [False] * 20
         self.generator.trials_in_block = 20
-        self.generator.spec.min_block_reward = 1
 
         result = self.generator._is_block_switch_allowed()
         self.assertFalse(result)

--- a/tests/trial_generators/test_warmup_trial_generator.py
+++ b/tests/trial_generators/test_warmup_trial_generator.py
@@ -41,17 +41,17 @@ class TestWarmup(unittest.TestCase):
             return
 
     def test_end_conditions_not_met_too_few_trials(self):
-        self.generator.is_right_choice_history.append([True] * 5)
+        self.generator.is_right_choice_history += [True] * 5
         self.assertFalse(self.generator._are_end_conditions_met())
 
     def test_end_conditions_not_met_high_bias(self):
         # all right choices = biased
-        self.generator.is_right_choice_history.append([True] * 10)
+        self.generator.is_right_choice_history += [True] * 10
         self.assertFalse(self.generator._are_end_conditions_met())
 
     def test_end_conditions_not_met_low_response_rate(self):
         # ignored
-        self.generator.is_right_choice_history.append([None] * 10)
+        self.generator.is_right_choice_history += [None] * 10
         self.assertFalse(self.generator._are_end_conditions_met())
 
     def test_end_conditions_met(self):
@@ -62,15 +62,15 @@ class TestWarmup(unittest.TestCase):
 
     ### block switches ###
 
-    def test_block_switches_every_update(self):
+    def test_block_switches_on_reward_minimum(self):
         initial_block = self.generator.block
         self.generator.update(make_outcome(is_right_choice=True, is_rewarded=True))
         self.assertIsNot(self.generator.block, initial_block)
 
-    def test_block_switches_on_ignored_trial(self):
+    def test_no_block_switch_on_reward_minimum_not_met(self):
         initial_block = self.generator.block
-        self.generator.update(make_outcome(is_right_choice=None, is_rewarded=False))
-        self.assertIsNot(self.generator.block, initial_block)
+        self.generator.update(make_outcome(is_right_choice=True, is_rewarded=False))
+        self.assertIs(self.generator.block, initial_block)
 
     def test_trials_in_block_resets_on_update(self):
         self.generator.trials_in_block = 5

--- a/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/coupled_baiting/stages.py
+++ b/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/coupled_baiting/stages.py
@@ -9,6 +9,9 @@ from aind_behavior_dynamic_foraging.task_logic.trial_generators import (
     CoupledWarmupTrialGeneratorSpec,
     TrialGeneratorCompositeSpec,
 )
+from aind_behavior_dynamic_foraging.task_logic.trial_generators.block_based_trial_generator import (
+    AutoWaterParameters,
+)
 from aind_behavior_dynamic_foraging.task_logic.trial_generators.coupled_trial_generators.base_coupled_trial_generator import (
     RewardProbabilityParameters,
 )
@@ -51,6 +54,9 @@ def make_s_stage_1_warmup():
                             is_baiting=True,
                             response_duration=5.0,
                             reward_consumption_duration=1.0,
+                            autowater_parameters=AutoWaterParameters(
+                                min_ignored_trials=0, min_unrewarded_trials=0, reward_fraction=0.8
+                            ),
                         ),
                         CoupledTrialGeneratorSpec(
                             trial_generation_end_parameters=CoupledTrialGenerationEndConditions(
@@ -83,6 +89,9 @@ def make_s_stage_1_warmup():
                             response_duration=5.0,
                             reward_consumption_duration=1.0,
                             kernel_size=2,
+                            autowater_parameters=AutoWaterParameters(
+                                min_ignored_trials=3, min_unrewarded_trials=3, reward_fraction=0.5
+                            ),
                         ),
                     ]
                 ),
@@ -129,6 +138,9 @@ def make_s_stage_1():
                     response_duration=5.0,
                     reward_consumption_duration=1.0,
                     kernel_size=2,
+                    autowater_parameters=AutoWaterParameters(
+                        min_ignored_trials=5, min_unrewarded_trials=5, reward_fraction=0.5
+                    ),
                 ),
             )
         ),
@@ -173,6 +185,9 @@ def make_s_stage_2():
                     response_duration=3.0,
                     reward_consumption_duration=1.0,
                     kernel_size=2,
+                    autowater_parameters=AutoWaterParameters(
+                        min_ignored_trials=7, min_unrewarded_trials=7, reward_fraction=0.5
+                    ),
                 ),
             )
         ),
@@ -217,6 +232,9 @@ def make_s_stage_3():
                     response_duration=2.0,
                     reward_consumption_duration=1.0,
                     kernel_size=2,
+                    autowater_parameters=AutoWaterParameters(
+                        min_ignored_trials=10, min_unrewarded_trials=10, reward_fraction=0.5
+                    ),
                 ),
             )
         ),
@@ -257,6 +275,7 @@ def make_s_stage_final():
                     response_duration=1.0,
                     reward_consumption_duration=3.0,
                     kernel_size=2,
+                    autowater_parameters=None,
                 ),
             )
         ),
@@ -297,6 +316,7 @@ def make_s_stage_graduated():
                     response_duration=1.0,
                     reward_consumption_duration=3.0,
                     kernel_size=2,
+                    autowater_parameters=None,
                 ),
             )
         ),

--- a/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/coupled_baiting/stages.py
+++ b/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/coupled_baiting/stages.py
@@ -37,6 +37,7 @@ def make_s_stage_1_warmup():
     return Stage(
         name="stage_1_warmup",
         task=AindDynamicForagingTaskLogic(
+            stage_name="stage_1_warmup",
             task_parameters=AindDynamicForagingTaskParameters(
                 reward_size=RewardSize(right_value_volume=4.0, left_value_volume=4.0),
                 trial_generator=TrialGeneratorCompositeSpec(
@@ -95,7 +96,7 @@ def make_s_stage_1_warmup():
                         ),
                     ]
                 ),
-            )
+            ),
         ),
         metrics_provider=MetricsProvider(metrics_from_dataset),
     )
@@ -105,6 +106,7 @@ def make_s_stage_1():
     return Stage(
         name="stage_1",
         task=AindDynamicForagingTaskLogic(
+            stage_name="stage_1",
             task_parameters=AindDynamicForagingTaskParameters(
                 reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=CoupledTrialGeneratorSpec(
@@ -142,7 +144,7 @@ def make_s_stage_1():
                         min_ignored_trials=5, min_unrewarded_trials=5, reward_fraction=0.5
                     ),
                 ),
-            )
+            ),
         ),
         metrics_provider=MetricsProvider(metrics_from_dataset),
     )
@@ -152,6 +154,7 @@ def make_s_stage_2():
     return Stage(
         name="stage_2",
         task=AindDynamicForagingTaskLogic(
+            stage_name="stage_2",
             task_parameters=AindDynamicForagingTaskParameters(
                 reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=CoupledTrialGeneratorSpec(
@@ -189,7 +192,7 @@ def make_s_stage_2():
                         min_ignored_trials=7, min_unrewarded_trials=7, reward_fraction=0.5
                     ),
                 ),
-            )
+            ),
         ),
         metrics_provider=MetricsProvider(metrics_from_dataset),
     )
@@ -199,6 +202,7 @@ def make_s_stage_3():
     return Stage(
         name="stage_3",
         task=AindDynamicForagingTaskLogic(
+            stage_name="stage_3",
             task_parameters=AindDynamicForagingTaskParameters(
                 reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=CoupledTrialGeneratorSpec(
@@ -236,7 +240,7 @@ def make_s_stage_3():
                         min_ignored_trials=10, min_unrewarded_trials=10, reward_fraction=0.5
                     ),
                 ),
-            )
+            ),
         ),
         metrics_provider=MetricsProvider(metrics_from_dataset),
     )
@@ -246,6 +250,7 @@ def make_s_stage_final():
     return Stage(
         name="final",
         task=AindDynamicForagingTaskLogic(
+            stage_name="final",
             task_parameters=AindDynamicForagingTaskParameters(
                 reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=CoupledTrialGeneratorSpec(
@@ -277,7 +282,7 @@ def make_s_stage_final():
                     kernel_size=2,
                     autowater_parameters=None,
                 ),
-            )
+            ),
         ),
         metrics_provider=MetricsProvider(metrics_from_dataset),
     )
@@ -287,6 +292,7 @@ def make_s_stage_graduated():
     return Stage(
         name="graduated",
         task=AindDynamicForagingTaskLogic(
+            stage_name="graduated",
             task_parameters=AindDynamicForagingTaskParameters(
                 reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=CoupledTrialGeneratorSpec(
@@ -318,7 +324,7 @@ def make_s_stage_graduated():
                     kernel_size=2,
                     autowater_parameters=None,
                 ),
-            )
+            ),
         ),
         metrics_provider=MetricsProvider(metrics_from_dataset),
     )

--- a/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/coupled_baiting/stages.py
+++ b/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/coupled_baiting/stages.py
@@ -43,6 +43,7 @@ def make_s_stage_1_warmup():
                 trial_generator=TrialGeneratorCompositeSpec(
                     generators=[
                         CoupledWarmupTrialGeneratorSpec(
+                            min_block_reward=1,
                             reward_probability_parameters=RewardProbabilityParameters(
                                 base_reward_sum=1, reward_pairs=[[1.0, 0.0]]
                             ),
@@ -84,7 +85,6 @@ def make_s_stage_1_warmup():
                                 truncation_parameters=TruncationParameters(truncation_mode="clamp", min=1, max=7),
                             ),
                             quiescent_duration=Scalar(distribution_parameters=ScalarDistributionParameter(value=0.1)),
-                            min_block_reward=0,
                             is_baiting=True,
                             extend_block_on_no_response=True,
                             response_duration=5.0,
@@ -134,7 +134,6 @@ def make_s_stage_1():
                         truncation_parameters=TruncationParameters(truncation_mode="clamp", min=1, max=7),
                     ),
                     quiescent_duration=Scalar(distribution_parameters=ScalarDistributionParameter(value=0.1)),
-                    min_block_reward=0,
                     is_baiting=True,
                     extend_block_on_no_response=True,
                     response_duration=5.0,
@@ -182,7 +181,6 @@ def make_s_stage_2():
                         truncation_parameters=TruncationParameters(truncation_mode="clamp", min=1, max=10),
                     ),
                     quiescent_duration=Scalar(distribution_parameters=ScalarDistributionParameter(value=0.3)),
-                    min_block_reward=0,
                     is_baiting=True,
                     extend_block_on_no_response=True,
                     response_duration=3.0,
@@ -230,7 +228,6 @@ def make_s_stage_3():
                         truncation_parameters=TruncationParameters(truncation_mode="clamp", min=1, max=15),
                     ),
                     quiescent_duration=Scalar(distribution_parameters=ScalarDistributionParameter(value=0.5)),
-                    min_block_reward=0,
                     is_baiting=True,
                     extend_block_on_no_response=True,
                     response_duration=2.0,
@@ -274,7 +271,6 @@ def make_s_stage_final():
                         truncation_parameters=TruncationParameters(truncation_mode="clamp", min=1, max=30),
                     ),
                     quiescent_duration=Scalar(distribution_parameters=ScalarDistributionParameter(value=1)),
-                    min_block_reward=0,
                     is_baiting=True,
                     extend_block_on_no_response=True,
                     response_duration=1.0,
@@ -316,7 +312,6 @@ def make_s_stage_graduated():
                         truncation_parameters=TruncationParameters(truncation_mode="clamp", min=1, max=30),
                     ),
                     quiescent_duration=Scalar(distribution_parameters=ScalarDistributionParameter(value=1)),
-                    min_block_reward=0,
                     is_baiting=True,
                     extend_block_on_no_response=True,
                     response_duration=1.0,

--- a/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/uncoupled/stages.py
+++ b/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/uncoupled/stages.py
@@ -46,6 +46,7 @@ def make_s_stage_1_warmup():
     return Stage(
         name="stage_1_warmup",
         task=AindDynamicForagingTaskLogic(
+            stage_name="stage_1_warmup",
             task_parameters=AindDynamicForagingTaskParameters(
                 reward_size=RewardSize(right_value_volume=4.0, left_value_volume=4.0),
                 trial_generator=TrialGeneratorCompositeSpec(
@@ -110,7 +111,7 @@ def make_s_stage_1_warmup():
                         ),
                     ]
                 ),
-            )
+            ),
         ),
         metrics_provider=MetricsProvider(metrics_from_dataset),
     )
@@ -120,6 +121,7 @@ def make_s_stage_1():
     return Stage(
         name="stage_1",
         task=AindDynamicForagingTaskLogic(
+            stage_name="stage_1",
             task_parameters=AindDynamicForagingTaskParameters(
                 reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=CoupledTrialGeneratorSpec(
@@ -157,7 +159,7 @@ def make_s_stage_1():
                     reward_consumption_duration=1.0,
                     kernel_size=2,
                 ),
-            )
+            ),
         ),
         metrics_provider=MetricsProvider(metrics_from_dataset),
     )
@@ -167,6 +169,7 @@ def make_s_stage_2():
     return Stage(
         name="stage_2",
         task=AindDynamicForagingTaskLogic(
+            stage_name="stage_2",
             task_parameters=AindDynamicForagingTaskParameters(
                 reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=CoupledTrialGeneratorSpec(
@@ -204,7 +207,7 @@ def make_s_stage_2():
                     reward_consumption_duration=1.0,
                     kernel_size=2,
                 ),
-            )
+            ),
         ),
         metrics_provider=MetricsProvider(metrics_from_dataset),
     )
@@ -214,6 +217,7 @@ def make_s_stage_3():
     return Stage(
         name="stage_3",
         task=AindDynamicForagingTaskLogic(
+            stage_name="stage_3",
             task_parameters=AindDynamicForagingTaskParameters(
                 reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=UncoupledTrialGeneratorSpec(
@@ -240,7 +244,7 @@ def make_s_stage_3():
                     response_duration=2.0,
                     reward_consumption_duration=1.0,
                 ),
-            )
+            ),
         ),
         metrics_provider=MetricsProvider(metrics_from_dataset),
     )
@@ -250,6 +254,7 @@ def make_s_stage_final():
     return Stage(
         name="final",
         task=AindDynamicForagingTaskLogic(
+            stage_name="final",
             task_parameters=AindDynamicForagingTaskParameters(
                 reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=UncoupledTrialGeneratorSpec(
@@ -274,7 +279,7 @@ def make_s_stage_final():
                     response_duration=1.0,
                     reward_consumption_duration=3.0,
                 ),
-            )
+            ),
         ),
         metrics_provider=MetricsProvider(metrics_from_dataset),
     )
@@ -284,6 +289,7 @@ def make_s_stage_graduated():
     return Stage(
         name="graduated",
         task=AindDynamicForagingTaskLogic(
+            stage_name="graduated",
             task_parameters=AindDynamicForagingTaskParameters(
                 reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=UncoupledTrialGeneratorSpec(
@@ -308,7 +314,7 @@ def make_s_stage_graduated():
                     response_duration=1.0,
                     reward_consumption_duration=3.0,
                 ),
-            )
+            ),
         ),
         metrics_provider=MetricsProvider(metrics_from_dataset),
     )

--- a/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/uncoupled/stages.py
+++ b/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/uncoupled/stages.py
@@ -52,6 +52,7 @@ def make_s_stage_1_warmup():
                 trial_generator=TrialGeneratorCompositeSpec(
                     generators=[
                         CoupledWarmupTrialGeneratorSpec(
+                            min_block_reward=1,
                             autowater_parameters=AutoWaterParameters(
                                 reward_fraction=0.8, min_ignored_trials=0, min_unrewarded_trials=0
                             ),
@@ -102,7 +103,6 @@ def make_s_stage_1_warmup():
                                 truncation_parameters=TruncationParameters(truncation_mode="clamp", min=1, max=7),
                             ),
                             quiescent_duration=Scalar(distribution_parameters=ScalarDistributionParameter(value=0.1)),
-                            min_block_reward=0,
                             is_baiting=True,
                             extend_block_on_no_response=True,
                             response_duration=5.0,
@@ -152,7 +152,6 @@ def make_s_stage_1():
                         truncation_parameters=TruncationParameters(truncation_mode="clamp", min=1, max=7),
                     ),
                     quiescent_duration=Scalar(distribution_parameters=ScalarDistributionParameter(value=0.1)),
-                    min_block_reward=0,
                     is_baiting=True,
                     extend_block_on_no_response=True,
                     response_duration=5.0,
@@ -200,7 +199,6 @@ def make_s_stage_2():
                         truncation_parameters=TruncationParameters(truncation_mode="clamp", min=1, max=10),
                     ),
                     quiescent_duration=Scalar(distribution_parameters=ScalarDistributionParameter(value=0.3)),
-                    min_block_reward=0,
                     is_baiting=False,
                     extend_block_on_no_response=True,
                     response_duration=3.0,

--- a/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/uncoupled/stages.py
+++ b/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/uncoupled/stages.py
@@ -52,7 +52,7 @@ def make_s_stage_1_warmup():
                     generators=[
                         CoupledWarmupTrialGeneratorSpec(
                             autowater_parameters=AutoWaterParameters(
-                                reward_fraction=0.5, min_ignored_trials=3, min_unrewarded_trials=3
+                                reward_fraction=0.8, min_ignored_trials=0, min_unrewarded_trials=0
                             ),
                             trial_generation_end_parameters=CoupledWarmupTrialGenerationEndConditions(
                                 min_trial=50,

--- a/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/uncoupled_baiting/stages.py
+++ b/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/uncoupled_baiting/stages.py
@@ -52,6 +52,7 @@ def make_s_stage_1_warmup():
                 trial_generator=TrialGeneratorCompositeSpec(
                     generators=[
                         CoupledWarmupTrialGeneratorSpec(
+                            min_block_reward=1,
                             trial_generation_end_parameters=CoupledWarmupTrialGenerationEndConditions(
                                 min_trial=50,
                                 max_choice_bias=0.1,
@@ -99,7 +100,6 @@ def make_s_stage_1_warmup():
                                 truncation_parameters=TruncationParameters(truncation_mode="clamp", min=1, max=7),
                             ),
                             quiescent_duration=Scalar(distribution_parameters=ScalarDistributionParameter(value=0.1)),
-                            min_block_reward=0,
                             is_baiting=True,
                             extend_block_on_no_response=True,
                             response_duration=5.0,
@@ -149,7 +149,6 @@ def make_s_stage_1():
                         truncation_parameters=TruncationParameters(truncation_mode="clamp", min=1, max=7),
                     ),
                     quiescent_duration=Scalar(distribution_parameters=ScalarDistributionParameter(value=0.1)),
-                    min_block_reward=0,
                     is_baiting=True,
                     extend_block_on_no_response=True,
                     response_duration=5.0,
@@ -197,7 +196,6 @@ def make_s_stage_2():
                         truncation_parameters=TruncationParameters(truncation_mode="clamp", min=1, max=10),
                     ),
                     quiescent_duration=Scalar(distribution_parameters=ScalarDistributionParameter(value=0.3)),
-                    min_block_reward=0,
                     is_baiting=True,
                     extend_block_on_no_response=True,
                     response_duration=3.0,

--- a/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/uncoupled_baiting/stages.py
+++ b/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/uncoupled_baiting/stages.py
@@ -46,6 +46,7 @@ def make_s_stage_1_warmup():
     return Stage(
         name="stage_1_warmup",
         task=AindDynamicForagingTaskLogic(
+            stage_name="stage_1_warmup",
             task_parameters=AindDynamicForagingTaskParameters(
                 reward_size=RewardSize(right_value_volume=4.0, left_value_volume=4.0),
                 trial_generator=TrialGeneratorCompositeSpec(
@@ -110,7 +111,7 @@ def make_s_stage_1_warmup():
                         ),
                     ]
                 ),
-            )
+            ),
         ),
         metrics_provider=MetricsProvider(metrics_from_dataset),
     )
@@ -120,6 +121,7 @@ def make_s_stage_1():
     return Stage(
         name="stage_1",
         task=AindDynamicForagingTaskLogic(
+            stage_name="stage_1",
             task_parameters=AindDynamicForagingTaskParameters(
                 reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=CoupledTrialGeneratorSpec(
@@ -157,7 +159,7 @@ def make_s_stage_1():
                         reward_fraction=0.5, min_ignored_trials=5, min_unrewarded_trials=5
                     ),
                 ),
-            )
+            ),
         ),
         metrics_provider=MetricsProvider(metrics_from_dataset),
     )
@@ -167,6 +169,7 @@ def make_s_stage_2():
     return Stage(
         name="stage_2",
         task=AindDynamicForagingTaskLogic(
+            stage_name="stage_2",
             task_parameters=AindDynamicForagingTaskParameters(
                 reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=CoupledTrialGeneratorSpec(
@@ -204,7 +207,7 @@ def make_s_stage_2():
                         reward_fraction=0.5, min_ignored_trials=7, min_unrewarded_trials=7
                     ),
                 ),
-            )
+            ),
         ),
         metrics_provider=MetricsProvider(metrics_from_dataset),
     )
@@ -214,6 +217,7 @@ def make_s_stage_3():
     return Stage(
         name="stage_3",
         task=AindDynamicForagingTaskLogic(
+            stage_name="stage_3",
             task_parameters=AindDynamicForagingTaskParameters(
                 reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=UncoupledTrialGeneratorSpec(
@@ -240,7 +244,7 @@ def make_s_stage_3():
                         reward_fraction=0.5, min_ignored_trials=10, min_unrewarded_trials=10
                     ),
                 ),
-            )
+            ),
         ),
         metrics_provider=MetricsProvider(metrics_from_dataset),
     )
@@ -250,6 +254,7 @@ def make_s_stage_final():
     return Stage(
         name="final",
         task=AindDynamicForagingTaskLogic(
+            stage_name="final",
             task_parameters=AindDynamicForagingTaskParameters(
                 reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=UncoupledTrialGeneratorSpec(
@@ -274,7 +279,7 @@ def make_s_stage_final():
                     reward_consumption_duration=3.0,
                     autowater_parameters=None,
                 ),
-            )
+            ),
         ),
         metrics_provider=MetricsProvider(metrics_from_dataset),
     )
@@ -284,6 +289,7 @@ def make_s_stage_graduated():
     return Stage(
         name="graduated",
         task=AindDynamicForagingTaskLogic(
+            stage_name="graduated",
             task_parameters=AindDynamicForagingTaskParameters(
                 reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=UncoupledTrialGeneratorSpec(
@@ -308,7 +314,7 @@ def make_s_stage_graduated():
                     reward_consumption_duration=3.0,
                     autowater_parameters=None,
                 ),
-            )
+            ),
         ),
         metrics_provider=MetricsProvider(metrics_from_dataset),
     )

--- a/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/uncoupled_baiting/stages.py
+++ b/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/uncoupled_baiting/stages.py
@@ -9,6 +9,9 @@ from aind_behavior_dynamic_foraging.task_logic.trial_generators import (
     CoupledWarmupTrialGeneratorSpec,
     TrialGeneratorCompositeSpec,
 )
+from aind_behavior_dynamic_foraging.task_logic.trial_generators.block_based_trial_generator import (
+    AutoWaterParameters,
+)
 from aind_behavior_dynamic_foraging.task_logic.trial_generators.coupled_trial_generators.base_coupled_trial_generator import (
     RewardProbabilityParameters,
 )
@@ -66,6 +69,9 @@ def make_s_stage_1_warmup():
                             is_baiting=True,
                             response_duration=5.0,
                             reward_consumption_duration=1.0,
+                            autowater_parameters=AutoWaterParameters(
+                                reward_fraction=0.8, min_ignored_trials=0, min_unrewarded_trials=0
+                            ),
                         ),
                         CoupledTrialGeneratorSpec(
                             trial_generation_end_parameters=CoupledTrialGenerationEndConditions(
@@ -98,6 +104,9 @@ def make_s_stage_1_warmup():
                             response_duration=5.0,
                             reward_consumption_duration=1.0,
                             kernel_size=2,
+                            autowater_parameters=AutoWaterParameters(
+                                reward_fraction=0.5, min_ignored_trials=3, min_unrewarded_trials=3
+                            ),
                         ),
                     ]
                 ),
@@ -144,6 +153,9 @@ def make_s_stage_1():
                     response_duration=5.0,
                     reward_consumption_duration=1.0,
                     kernel_size=2,
+                    autowater_parameters=AutoWaterParameters(
+                        reward_fraction=0.5, min_ignored_trials=5, min_unrewarded_trials=5
+                    ),
                 ),
             )
         ),
@@ -188,6 +200,9 @@ def make_s_stage_2():
                     response_duration=3.0,
                     reward_consumption_duration=1.0,
                     kernel_size=2,
+                    autowater_parameters=AutoWaterParameters(
+                        reward_fraction=0.5, min_ignored_trials=7, min_unrewarded_trials=7
+                    ),
                 ),
             )
         ),
@@ -221,6 +236,9 @@ def make_s_stage_3():
                     is_baiting=True,
                     response_duration=2.0,
                     reward_consumption_duration=1.0,
+                    autowater_parameters=AutoWaterParameters(
+                        reward_fraction=0.5, min_ignored_trials=10, min_unrewarded_trials=10
+                    ),
                 ),
             )
         ),
@@ -254,6 +272,7 @@ def make_s_stage_final():
                     is_baiting=True,
                     response_duration=1.0,
                     reward_consumption_duration=3.0,
+                    autowater_parameters=None,
                 ),
             )
         ),
@@ -287,6 +306,7 @@ def make_s_stage_graduated():
                     is_baiting=True,
                     response_duration=1.0,
                     reward_consumption_duration=3.0,
+                    autowater_parameters=None,
                 ),
             )
         ),


### PR DESCRIPTION
Fixes autowater in curriculums subsequently fixing warmup bug of block not switching every trial. Also adds minimum reward check into warmup and removes from coupled trial generator 

While I was fixing curriculums also added stage names to task logic

closes #110 
closes #108