### PR TITLE
Add basic hardware quality control assurance to workflow

### DIFF
--- a/.bonsai/Bonsai.config
+++ b/.bonsai/Bonsai.config
@@ -11,6 +11,7 @@
     <Package id="AllenNeuralDynamics.LicketySplit" version="0.2.0" />
     <Package id="AllenNeuralDynamics.SniffDetector" version="0.2.0" />
     <Package id="AllenNeuralDynamics.Treadmill" version="0.2.0" />
+    <Package id="AllenNeuralDynamics.VersionControl" version="0.1.1" />
     <Package id="AllenNeuralDynamics.WhiteRabbit" version="0.2.0" />
     <Package id="AssimpNet" version="4.1.0" />
     <Package id="Bonsai" version="2.9.0" />
@@ -50,6 +51,8 @@
     <Package id="Hexa.NET.ImPlot" version="2.2.9" />
     <Package id="HexaGen.Runtime" version="1.1.21" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
+    <Package id="LibGit2Sharp" version="0.27.2" />
+    <Package id="LibGit2Sharp.NativeBinaries" version="2.0.320" />
     <Package id="LibUsbDotNet" version="2.2.29" />
     <Package id="Markdig" version="0.41.1" />
     <Package id="MathNet.Numerics" version="4.15.0" />
@@ -87,6 +90,7 @@
     <AssemblyReference assemblyName="AllenNeuralDynamics.LicketySplit" />
     <AssemblyReference assemblyName="AllenNeuralDynamics.SniffDetector" />
     <AssemblyReference assemblyName="AllenNeuralDynamics.Treadmill" />
+    <AssemblyReference assemblyName="AllenNeuralDynamics.VersionControl" />
     <AssemblyReference assemblyName="AllenNeuralDynamics.WhiteRabbit" />
     <AssemblyReference assemblyName="Bonsai" />
     <AssemblyReference assemblyName="Bonsai.Core" />
@@ -130,6 +134,7 @@
     <AssemblyLocation assemblyName="AllenNeuralDynamics.LicketySplit" processorArchitecture="MSIL" location="Packages/AllenNeuralDynamics.LicketySplit.0.2.0/lib/net462/AllenNeuralDynamics.LicketySplit.dll" />
     <AssemblyLocation assemblyName="AllenNeuralDynamics.SniffDetector" processorArchitecture="MSIL" location="Packages/AllenNeuralDynamics.SniffDetector.0.2.0/lib/net462/AllenNeuralDynamics.SniffDetector.dll" />
     <AssemblyLocation assemblyName="AllenNeuralDynamics.Treadmill" processorArchitecture="MSIL" location="Packages/AllenNeuralDynamics.Treadmill.0.2.0/lib/net462/AllenNeuralDynamics.Treadmill.dll" />
+    <AssemblyLocation assemblyName="AllenNeuralDynamics.VersionControl" processorArchitecture="MSIL" location="Packages/AllenNeuralDynamics.VersionControl.0.1.1/lib/net472/AllenNeuralDynamics.VersionControl.dll" />
     <AssemblyLocation assemblyName="AllenNeuralDynamics.WhiteRabbit" processorArchitecture="MSIL" location="Packages/AllenNeuralDynamics.WhiteRabbit.0.2.0/lib/net462/AllenNeuralDynamics.WhiteRabbit.dll" />
     <AssemblyLocation assemblyName="AssimpNet" processorArchitecture="MSIL" location="Packages/AssimpNet.4.1.0/lib/net40/AssimpNet.dll" />
     <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
@@ -166,6 +171,7 @@
     <AssemblyLocation assemblyName="Hexa.NET.ImGui.Backends" processorArchitecture="MSIL" location="Packages/Hexa.NET.ImGui.Backends.1.0.18/lib/netstandard2.0/Hexa.NET.ImGui.Backends.dll" />
     <AssemblyLocation assemblyName="Hexa.NET.ImPlot" processorArchitecture="MSIL" location="Packages/Hexa.NET.ImPlot.2.2.9/lib/netstandard2.0/Hexa.NET.ImPlot.dll" />
     <AssemblyLocation assemblyName="HexaGen.Runtime" processorArchitecture="MSIL" location="Packages/HexaGen.Runtime.1.1.21/lib/net472/HexaGen.Runtime.dll" />
+    <AssemblyLocation assemblyName="LibGit2Sharp" processorArchitecture="MSIL" location="Packages/LibGit2Sharp.0.27.2/lib/net472/LibGit2Sharp.dll" />
     <AssemblyLocation assemblyName="LibUsbDotNet.LibUsbDotNet" processorArchitecture="MSIL" location="Packages/LibUsbDotNet.2.2.29/lib/net45/LibUsbDotNet.LibUsbDotNet.dll" />
     <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />
     <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages/MathNet.Numerics.4.15.0/lib/net461/MathNet.Numerics.dll" />
@@ -211,6 +217,9 @@
     <LibraryFolder path="Packages/Hexa.NET.ImPlot.2.2.9/runtimes/win-arm64/native" platform="arm64" />
     <LibraryFolder path="Packages/Hexa.NET.ImPlot.2.2.9/runtimes/win-x64/native" platform="x64" />
     <LibraryFolder path="Packages/Hexa.NET.ImPlot.2.2.9/runtimes/win-x86/native" platform="x86" />
+    <LibraryFolder path="Packages/LibGit2Sharp.NativeBinaries.2.0.320/runtimes/win-arm64/native" platform="arm64" />
+    <LibraryFolder path="Packages/LibGit2Sharp.NativeBinaries.2.0.320/runtimes/win-x64/native" platform="x64" />
+    <LibraryFolder path="Packages/LibGit2Sharp.NativeBinaries.2.0.320/runtimes/win-x86/native" platform="x86" />
     <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native" platform="arm64" />
     <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native_uap" platform="arm64" />
     <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native" platform="x64" />

--- a/src/Extensions/HardwareQA.bonsai
+++ b/src/Extensions/HardwareQA.bonsai
@@ -6,7 +6,6 @@
                  xmlns:p1="clr-namespace:AllenNeuralDynamics.Core;assembly=AllenNeuralDynamics.Core"
                  xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
                  xmlns:p2="clr-namespace:AllenNeuralDynamics.VersionControl;assembly=AllenNeuralDynamics.VersionControl"
-                 xmlns:gl="clr-namespace:Bonsai.Shaders;assembly=Bonsai.Shaders"
                  xmlns:p3="clr-namespace:AllenNeuralDynamics.Core.Design;assembly=AllenNeuralDynamics.Core.Design"
                  xmlns:p4="clr-namespace:System.Reactive;assembly=System.Reactive.Core"
                  xmlns:io="clr-namespace:Bonsai.IO;assembly=Bonsai.System"
@@ -457,9 +456,9 @@
                                 <Property Name="Period" DisplayName="SnoozeTime" />
                               </Expression>
                               <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="gl:Timer">
-                                  <gl:DueTime>PT0S</gl:DueTime>
-                                  <gl:Period>PT10S</gl:Period>
+                                <Combinator xsi:type="rx:Timer">
+                                  <rx:DueTime>PT0S</rx:DueTime>
+                                  <rx:Period>PT10S</rx:Period>
                                 </Combinator>
                               </Expression>
                               <Expression xsi:type="Combinator">
@@ -564,8 +563,8 @@
               <Combinator xsi:type="rx:SubscribeWhen" />
             </Expression>
             <Expression xsi:type="Combinator">
-              <Combinator xsi:type="gl:DelaySubscription">
-                <gl:DueTime>PT2S</gl:DueTime>
+              <Combinator xsi:type="rx:DelaySubscription">
+                <rx:DueTime>PT2S</rx:DueTime>
               </Combinator>
             </Expression>
             <Expression xsi:type="Combinator">

--- a/src/Extensions/HardwareQA.bonsai
+++ b/src/Extensions/HardwareQA.bonsai
@@ -1,0 +1,660 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.9.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:dsp="clr-namespace:Bonsai.Dsp;assembly=Bonsai.Dsp"
+                 xmlns:p1="clr-namespace:AllenNeuralDynamics.Core;assembly=AllenNeuralDynamics.Core"
+                 xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
+                 xmlns:p2="clr-namespace:AllenNeuralDynamics.VersionControl;assembly=AllenNeuralDynamics.VersionControl"
+                 xmlns:gl="clr-namespace:Bonsai.Shaders;assembly=Bonsai.Shaders"
+                 xmlns:p3="clr-namespace:AllenNeuralDynamics.Core.Design;assembly=AllenNeuralDynamics.Core.Design"
+                 xmlns:p4="clr-namespace:System.Reactive;assembly=System.Reactive.Core"
+                 xmlns:io="clr-namespace:Bonsai.IO;assembly=Bonsai.System"
+                 xmlns:p5="clr-namespace:;assembly=Extensions"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="rx:Defer">
+        <Name>HardwareChecks</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="GroupWorkflow">
+              <Name>ProtocolValidation</Name>
+              <Workflow>
+                <Nodes>
+                  <Expression xsi:type="GroupWorkflow">
+                    <Name>PreSession</Name>
+                    <Workflow>
+                      <Nodes>
+                        <Expression xsi:type="IncludeWorkflow" Path="Extensions\ValidateClkOutput.bonsai" />
+                        <Expression xsi:type="rx:Defer">
+                          <Name>Cameras</Name>
+                          <Workflow>
+                            <Nodes>
+                              <Expression xsi:type="SubscribeSubject">
+                                <Name>TriggeredCamerasStream</Name>
+                              </Expression>
+                              <Expression xsi:type="rx:CreateObservable">
+                                <Name>CheckDroppedFrames</Name>
+                                <Workflow>
+                                  <Nodes>
+                                    <Expression xsi:type="WorkflowInput">
+                                      <Name>Source1</Name>
+                                    </Expression>
+                                    <Expression xsi:type="Combinator">
+                                      <Combinator xsi:type="rx:Take">
+                                        <rx:Count>1</rx:Count>
+                                      </Combinator>
+                                    </Expression>
+                                    <Expression xsi:type="rx:AsyncSubject">
+                                      <Name>InputSequence</Name>
+                                    </Expression>
+                                    <Expression xsi:type="SubscribeSubject">
+                                      <Name>InputSequence</Name>
+                                    </Expression>
+                                    <Expression xsi:type="Combinator">
+                                      <Combinator xsi:type="rx:Merge" />
+                                    </Expression>
+                                    <Expression xsi:type="MemberSelector">
+                                      <Selector>Value.ChunkData</Selector>
+                                    </Expression>
+                                    <Expression xsi:type="MemberSelector">
+                                      <Selector>FrameID</Selector>
+                                    </Expression>
+                                    <Expression xsi:type="Combinator">
+                                      <Combinator xsi:type="dsp:Difference">
+                                        <dsp:Order>1</dsp:Order>
+                                      </Combinator>
+                                    </Expression>
+                                    <Expression xsi:type="Subtract">
+                                      <Operand xsi:type="DoubleProperty">
+                                        <Value>1</Value>
+                                      </Operand>
+                                    </Expression>
+                                    <Expression xsi:type="GreaterThan">
+                                      <Operand xsi:type="DoubleProperty">
+                                        <Value>0</Value>
+                                      </Operand>
+                                    </Expression>
+                                    <Expression xsi:type="rx:Condition">
+                                      <Workflow>
+                                        <Nodes>
+                                          <Expression xsi:type="WorkflowInput">
+                                            <Name>Source1</Name>
+                                          </Expression>
+                                          <Expression xsi:type="WorkflowOutput" />
+                                        </Nodes>
+                                        <Edges>
+                                          <Edge From="0" To="1" Label="Source1" />
+                                        </Edges>
+                                      </Workflow>
+                                    </Expression>
+                                    <Expression xsi:type="SubscribeSubject">
+                                      <Name>InputSequence</Name>
+                                    </Expression>
+                                    <Expression xsi:type="MemberSelector">
+                                      <Selector>Key</Selector>
+                                    </Expression>
+                                    <Expression xsi:type="Combinator">
+                                      <Combinator xsi:type="rx:WithLatestFrom" />
+                                    </Expression>
+                                    <Expression xsi:type="MemberSelector">
+                                      <Selector>Item2</Selector>
+                                    </Expression>
+                                    <Expression xsi:type="WorkflowOutput" />
+                                  </Nodes>
+                                  <Edges>
+                                    <Edge From="0" To="1" Label="Source1" />
+                                    <Edge From="1" To="2" Label="Source1" />
+                                    <Edge From="3" To="4" Label="Source1" />
+                                    <Edge From="4" To="5" Label="Source1" />
+                                    <Edge From="5" To="6" Label="Source1" />
+                                    <Edge From="6" To="7" Label="Source1" />
+                                    <Edge From="7" To="8" Label="Source1" />
+                                    <Edge From="8" To="9" Label="Source1" />
+                                    <Edge From="9" To="10" Label="Source1" />
+                                    <Edge From="10" To="13" Label="Source1" />
+                                    <Edge From="11" To="12" Label="Source1" />
+                                    <Edge From="12" To="13" Label="Source2" />
+                                    <Edge From="13" To="14" Label="Source1" />
+                                    <Edge From="14" To="15" Label="Source1" />
+                                  </Edges>
+                                </Workflow>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:Merge" />
+                              </Expression>
+                              <Expression xsi:type="Format">
+                                <Format>Camera {0} dropped frame detected during pre-session!</Format>
+                                <Selector>it</Selector>
+                              </Expression>
+                              <Expression xsi:type="InputMapping">
+                                <PropertyMappings>
+                                  <Property Name="Message" Selector="it" />
+                                </PropertyMappings>
+                                <Selector>it</Selector>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="p1:ThrowException">
+                                  <p1:Message>Dropped frame detected during pre-session!</p1:Message>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="SubscribeSubject">
+                                <Name>StartExperiment</Name>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:TakeUntil" />
+                              </Expression>
+                              <Expression xsi:type="SubscribeSubject">
+                                <Name>TriggeredCameraController</Name>
+                              </Expression>
+                              <Expression xsi:type="MemberSelector">
+                                <Selector>Cameras</Selector>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:Merge" />
+                              </Expression>
+                              <Expression xsi:type="rx:CreateObservable">
+                                <Name>CheckCameraSettings</Name>
+                                <Workflow>
+                                  <Nodes>
+                                    <Expression xsi:type="WorkflowInput">
+                                      <Name>Source1</Name>
+                                    </Expression>
+                                    <Expression xsi:type="Combinator">
+                                      <Combinator xsi:type="rx:Take">
+                                        <rx:Count>1</rx:Count>
+                                      </Combinator>
+                                    </Expression>
+                                    <Expression xsi:type="rx:AsyncSubject">
+                                      <Name>ThisCamera</Name>
+                                    </Expression>
+                                    <Expression xsi:type="SubscribeSubject">
+                                      <Name>ThisCamera</Name>
+                                    </Expression>
+                                    <Expression xsi:type="MemberSelector">
+                                      <Selector>Value.Exposure</Selector>
+                                    </Expression>
+                                    <Expression xsi:type="SubscribeSubject">
+                                      <Name>TriggeredCameraController</Name>
+                                    </Expression>
+                                    <Expression xsi:type="MemberSelector">
+                                      <Selector>FrameRate</Selector>
+                                    </Expression>
+                                    <Expression xsi:type="MemberSelector">
+                                      <Selector>Value</Selector>
+                                    </Expression>
+                                    <Expression xsi:type="Combinator">
+                                      <Combinator xsi:type="rx:Zip" />
+                                    </Expression>
+                                    <Expression xsi:type="scr:ExpressionTransform">
+                                      <scr:Expression>((1.0 / Item2) * 1000000) &lt; double(Item1) + 1000</scr:Expression>
+                                    </Expression>
+                                    <Expression xsi:type="rx:Condition">
+                                      <Workflow>
+                                        <Nodes>
+                                          <Expression xsi:type="WorkflowInput">
+                                            <Name>Source1</Name>
+                                          </Expression>
+                                          <Expression xsi:type="WorkflowOutput" />
+                                        </Nodes>
+                                        <Edges>
+                                          <Edge From="0" To="1" Label="Source1" />
+                                        </Edges>
+                                      </Workflow>
+                                    </Expression>
+                                    <Expression xsi:type="Combinator">
+                                      <Combinator xsi:type="rx:Take">
+                                        <rx:Count>1</rx:Count>
+                                      </Combinator>
+                                    </Expression>
+                                    <Expression xsi:type="SubscribeSubject">
+                                      <Name>ThisCamera</Name>
+                                    </Expression>
+                                    <Expression xsi:type="MemberSelector">
+                                      <Selector>Key</Selector>
+                                    </Expression>
+                                    <Expression xsi:type="Combinator">
+                                      <Combinator xsi:type="rx:WithLatestFrom" />
+                                    </Expression>
+                                    <Expression xsi:type="WorkflowOutput" />
+                                  </Nodes>
+                                  <Edges>
+                                    <Edge From="0" To="1" Label="Source1" />
+                                    <Edge From="1" To="2" Label="Source1" />
+                                    <Edge From="3" To="4" Label="Source1" />
+                                    <Edge From="4" To="8" Label="Source1" />
+                                    <Edge From="5" To="6" Label="Source1" />
+                                    <Edge From="6" To="7" Label="Source1" />
+                                    <Edge From="7" To="8" Label="Source2" />
+                                    <Edge From="8" To="9" Label="Source1" />
+                                    <Edge From="9" To="10" Label="Source1" />
+                                    <Edge From="10" To="11" Label="Source1" />
+                                    <Edge From="11" To="14" Label="Source1" />
+                                    <Edge From="12" To="13" Label="Source1" />
+                                    <Edge From="13" To="14" Label="Source2" />
+                                    <Edge From="14" To="15" Label="Source1" />
+                                  </Edges>
+                                </Workflow>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:Merge" />
+                              </Expression>
+                              <Expression xsi:type="Format">
+                                <Format>Camera {0} exposure setting not compatible with requested frame rate!</Format>
+                                <Selector>it</Selector>
+                              </Expression>
+                              <Expression xsi:type="InputMapping">
+                                <PropertyMappings>
+                                  <Property Name="Message" Selector="it" />
+                                </PropertyMappings>
+                                <Selector>it</Selector>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="p1:ThrowException">
+                                  <p1:Message />
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="SubscribeSubject">
+                                <Name>TriggeredCameraController</Name>
+                              </Expression>
+                              <Expression xsi:type="MemberSelector">
+                                <Selector>FrameRate.HasValue</Selector>
+                              </Expression>
+                              <Expression xsi:type="BitwiseNot" />
+                              <Expression xsi:type="rx:Condition">
+                                <Workflow>
+                                  <Nodes>
+                                    <Expression xsi:type="WorkflowInput">
+                                      <Name>Source1</Name>
+                                    </Expression>
+                                    <Expression xsi:type="WorkflowOutput" />
+                                  </Nodes>
+                                  <Edges>
+                                    <Edge From="0" To="1" Label="Source1" />
+                                  </Edges>
+                                </Workflow>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="p1:ThrowException">
+                                  <p1:Message>TriggeredCameraControl must specify a valid FrameRate property!</p1:Message>
+                                </Combinator>
+                              </Expression>
+                            </Nodes>
+                            <Edges>
+                              <Edge From="0" To="1" Label="Source1" />
+                              <Edge From="1" To="2" Label="Source1" />
+                              <Edge From="2" To="3" Label="Source1" />
+                              <Edge From="3" To="4" Label="Source1" />
+                              <Edge From="4" To="5" Label="Source1" />
+                              <Edge From="5" To="7" Label="Source1" />
+                              <Edge From="6" To="7" Label="Source2" />
+                              <Edge From="8" To="9" Label="Source1" />
+                              <Edge From="9" To="10" Label="Source1" />
+                              <Edge From="10" To="11" Label="Source1" />
+                              <Edge From="11" To="12" Label="Source1" />
+                              <Edge From="12" To="13" Label="Source1" />
+                              <Edge From="13" To="14" Label="Source1" />
+                              <Edge From="14" To="15" Label="Source1" />
+                              <Edge From="16" To="17" Label="Source1" />
+                              <Edge From="17" To="18" Label="Source1" />
+                              <Edge From="18" To="19" Label="Source1" />
+                              <Edge From="19" To="20" Label="Source1" />
+                            </Edges>
+                          </Workflow>
+                        </Expression>
+                        <Expression xsi:type="rx:Defer">
+                          <Name>GitRepository</Name>
+                          <Workflow>
+                            <Nodes>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="p2:CreateRepository">
+                                  <p2:Path>../.</p2:Path>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="p2:IsRepositoryClean">
+                                  <p2:IgnoreUntracked>false</p2:IgnoreUntracked>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="BitwiseNot" />
+                              <Expression xsi:type="SubscribeSubject">
+                                <Name>SessionSchema</Name>
+                              </Expression>
+                              <Expression xsi:type="MemberSelector">
+                                <Selector>AllowDirtyRepo</Selector>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:Zip" />
+                              </Expression>
+                              <Expression xsi:type="scr:ExpressionTransform">
+                                <scr:Name>AllowDirty?</scr:Name>
+                                <scr:Expression>Item2 ? False : Item1</scr:Expression>
+                              </Expression>
+                              <Expression xsi:type="rx:Condition">
+                                <Workflow>
+                                  <Nodes>
+                                    <Expression xsi:type="WorkflowInput">
+                                      <Name>Source1</Name>
+                                    </Expression>
+                                    <Expression xsi:type="WorkflowOutput" />
+                                  </Nodes>
+                                  <Edges>
+                                    <Edge From="0" To="1" Label="Source1" />
+                                  </Edges>
+                                </Workflow>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="p1:ThrowException">
+                                  <p1:Message>Repository is not clean! Please discard all local changes.</p1:Message>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="WorkflowOutput" />
+                            </Nodes>
+                            <Edges>
+                              <Edge From="0" To="1" Label="Source1" />
+                              <Edge From="1" To="2" Label="Source1" />
+                              <Edge From="2" To="5" Label="Source1" />
+                              <Edge From="3" To="4" Label="Source1" />
+                              <Edge From="4" To="5" Label="Source2" />
+                              <Edge From="5" To="6" Label="Source1" />
+                              <Edge From="6" To="7" Label="Source1" />
+                              <Edge From="7" To="8" Label="Source1" />
+                              <Edge From="8" To="9" Label="Source1" />
+                            </Edges>
+                          </Workflow>
+                        </Expression>
+                      </Nodes>
+                      <Edges />
+                    </Workflow>
+                  </Expression>
+                  <Expression xsi:type="rx:Defer">
+                    <Name>CameraChecks</Name>
+                    <Workflow>
+                      <Nodes>
+                        <Expression xsi:type="SubscribeSubject">
+                          <Name>TriggeredCamerasStream</Name>
+                        </Expression>
+                        <Expression xsi:type="rx:CreateObservable">
+                          <Name>OnlineQC</Name>
+                          <Workflow>
+                            <Nodes>
+                              <Expression xsi:type="WorkflowInput">
+                                <Name>Source1</Name>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:Take">
+                                  <rx:Count>1</rx:Count>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="rx:AsyncSubject">
+                                <Name>InputSequence</Name>
+                              </Expression>
+                              <Expression xsi:type="SubscribeSubject">
+                                <Name>InputSequence</Name>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:Merge" />
+                              </Expression>
+                              <Expression xsi:type="MemberSelector">
+                                <Selector>Value.ChunkData</Selector>
+                              </Expression>
+                              <Expression xsi:type="MemberSelector">
+                                <Selector>Timestamp</Selector>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="dsp:Difference">
+                                  <dsp:Order>1</dsp:Order>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="Multiply">
+                                <Operand xsi:type="DoubleProperty">
+                                  <Value>1E-09</Value>
+                                </Operand>
+                              </Expression>
+                              <Expression xsi:type="MemberSelector">
+                                <Selector>Seconds</Selector>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="dsp:Difference">
+                                  <dsp:Order>1</dsp:Order>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:Zip" />
+                              </Expression>
+                              <Expression xsi:type="Subtract" />
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="dsp:Abs" />
+                              </Expression>
+                              <Expression xsi:type="ExternalizedMapping">
+                                <Property Name="Value" DisplayName="JitterThreshold" />
+                              </Expression>
+                              <Expression xsi:type="GreaterThan">
+                                <Operand xsi:type="DoubleProperty">
+                                  <Value>0.0005</Value>
+                                </Operand>
+                              </Expression>
+                              <Expression xsi:type="rx:Condition">
+                                <Workflow>
+                                  <Nodes>
+                                    <Expression xsi:type="WorkflowInput">
+                                      <Name>Source1</Name>
+                                    </Expression>
+                                    <Expression xsi:type="WorkflowOutput" />
+                                  </Nodes>
+                                  <Edges>
+                                    <Edge From="0" To="1" Label="Source1" />
+                                  </Edges>
+                                </Workflow>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:ObserveOn">
+                                  <rx:Scheduler>TaskPoolScheduler</rx:Scheduler>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="ExternalizedMapping">
+                                <Property Name="Period" DisplayName="SnoozeTime" />
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="gl:Timer">
+                                  <gl:DueTime>PT0S</gl:DueTime>
+                                  <gl:Period>PT10S</gl:Period>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:Gate" />
+                              </Expression>
+                              <Expression xsi:type="rx:SelectMany">
+                                <Name>MakeUI</Name>
+                                <Workflow>
+                                  <Nodes>
+                                    <Expression xsi:type="SubscribeSubject">
+                                      <Name>InputSequence</Name>
+                                    </Expression>
+                                    <Expression xsi:type="MemberSelector">
+                                      <Selector>Key</Selector>
+                                    </Expression>
+                                    <Expression xsi:type="Format">
+                                      <Format>Camera {0} out-of-alignment qc was triggered.</Format>
+                                      <Selector>it</Selector>
+                                    </Expression>
+                                    <Expression xsi:type="InputMapping">
+                                      <PropertyMappings>
+                                        <Property Name="Text" Selector="it" />
+                                      </PropertyMappings>
+                                    </Expression>
+                                    <Expression xsi:type="Combinator">
+                                      <Combinator xsi:type="p3:MessageBox">
+                                        <p3:Text />
+                                        <p3:Title>Warning</p3:Title>
+                                        <p3:MessageBoxIcon>Exclamation</p3:MessageBoxIcon>
+                                      </Combinator>
+                                    </Expression>
+                                  </Nodes>
+                                  <Edges>
+                                    <Edge From="0" To="1" Label="Source1" />
+                                    <Edge From="1" To="2" Label="Source1" />
+                                    <Edge From="2" To="3" Label="Source1" />
+                                    <Edge From="3" To="4" Label="Source1" />
+                                  </Edges>
+                                </Workflow>
+                              </Expression>
+                            </Nodes>
+                            <Edges>
+                              <Edge From="0" To="1" Label="Source1" />
+                              <Edge From="1" To="2" Label="Source1" />
+                              <Edge From="3" To="4" Label="Source1" />
+                              <Edge From="4" To="5" Label="Source1" />
+                              <Edge From="4" To="9" Label="Source1" />
+                              <Edge From="5" To="6" Label="Source1" />
+                              <Edge From="6" To="7" Label="Source1" />
+                              <Edge From="7" To="8" Label="Source1" />
+                              <Edge From="8" To="11" Label="Source1" />
+                              <Edge From="9" To="10" Label="Source1" />
+                              <Edge From="10" To="11" Label="Source2" />
+                              <Edge From="11" To="12" Label="Source1" />
+                              <Edge From="12" To="13" Label="Source1" />
+                              <Edge From="13" To="15" Label="Source1" />
+                              <Edge From="14" To="15" Label="Source2" />
+                              <Edge From="15" To="16" Label="Source1" />
+                              <Edge From="16" To="17" Label="Source1" />
+                              <Edge From="17" To="20" Label="Source1" />
+                              <Edge From="18" To="19" Label="Source1" />
+                              <Edge From="19" To="20" Label="Source2" />
+                              <Edge From="20" To="21" Label="Source1" />
+                            </Edges>
+                          </Workflow>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="rx:Merge" />
+                        </Expression>
+                      </Nodes>
+                      <Edges>
+                        <Edge From="0" To="1" Label="Source1" />
+                        <Edge From="1" To="2" Label="Source1" />
+                      </Edges>
+                    </Workflow>
+                  </Expression>
+                </Nodes>
+                <Edges />
+              </Workflow>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>SessionSchema</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>SkipHardwareValidation</Selector>
+            </Expression>
+            <Expression xsi:type="BitwiseNot" />
+            <Expression xsi:type="rx:Condition">
+              <Workflow>
+                <Nodes>
+                  <Expression xsi:type="WorkflowInput">
+                    <Name>Source1</Name>
+                  </Expression>
+                  <Expression xsi:type="WorkflowOutput" />
+                </Nodes>
+                <Edges>
+                  <Edge From="0" To="1" Label="Source1" />
+                </Edges>
+              </Workflow>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:SubscribeWhen" />
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="gl:DelaySubscription">
+                <gl:DueTime>PT2S</gl:DueTime>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Materialize" />
+            </Expression>
+            <Expression xsi:type="rx:Condition">
+              <Name>FilterErrors</Name>
+              <Workflow>
+                <Nodes>
+                  <Expression xsi:type="WorkflowInput">
+                    <Name>Source1</Name>
+                  </Expression>
+                  <Expression xsi:type="MemberSelector">
+                    <Selector>Kind</Selector>
+                  </Expression>
+                  <Expression xsi:type="Equal">
+                    <Operand xsi:type="WorkflowProperty" TypeArguments="p4:NotificationKind">
+                      <Value>OnError</Value>
+                    </Operand>
+                  </Expression>
+                  <Expression xsi:type="WorkflowOutput" />
+                </Nodes>
+                <Edges>
+                  <Edge From="0" To="1" Label="Source1" />
+                  <Edge From="1" To="2" Label="Source1" />
+                  <Edge From="2" To="3" Label="Source1" />
+                </Edges>
+              </Workflow>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Exception</Selector>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="io:WriteLine" />
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="p5:MessageBox">
+                <p5:Text />
+                <p5:Title>Error</p5:Title>
+                <p5:MessageBoxIcon>Hand</p5:MessageBoxIcon>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="rx:SelectMany">
+              <Name>CloseWorkflow</Name>
+              <Workflow>
+                <Nodes>
+                  <Expression xsi:type="WorkflowInput">
+                    <Name>Source1</Name>
+                  </Expression>
+                  <Expression xsi:type="Unit" />
+                  <Expression xsi:type="MulticastSubject">
+                    <Name>EndExperiment</Name>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:Take">
+                      <rx:Count>1</rx:Count>
+                    </Combinator>
+                  </Expression>
+                  <Expression xsi:type="WorkflowOutput" />
+                </Nodes>
+                <Edges>
+                  <Edge From="0" To="1" Label="Source1" />
+                  <Edge From="1" To="2" Label="Source1" />
+                  <Edge From="2" To="3" Label="Source1" />
+                  <Edge From="3" To="4" Label="Source1" />
+                </Edges>
+              </Workflow>
+            </Expression>
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="5" Label="Source1" />
+            <Edge From="1" To="2" Label="Source1" />
+            <Edge From="2" To="3" Label="Source1" />
+            <Edge From="3" To="4" Label="Source1" />
+            <Edge From="4" To="5" Label="Source2" />
+            <Edge From="5" To="6" Label="Source1" />
+            <Edge From="6" To="7" Label="Source1" />
+            <Edge From="7" To="8" Label="Source1" />
+            <Edge From="8" To="9" Label="Source1" />
+            <Edge From="9" To="10" Label="Source1" />
+            <Edge From="10" To="11" Label="Source1" />
+            <Edge From="11" To="12" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/src/Extensions/MessageBox.cs
+++ b/src/Extensions/MessageBox.cs
@@ -1,0 +1,76 @@
+﻿using Bonsai;
+using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+[Combinator]
+[Description("Creates a custom message box dialog window.")]
+[WorkflowElementCategory(ElementCategory.Sink)]
+public class MessageBox
+{
+    private string text = "";
+    public string Text
+    {
+        get { return text; }
+        set { text = value; }
+    }
+
+    private string title = "Warning";
+    public string Title
+    {
+        get { return title; }
+        set { title = value; }
+    }
+
+    private MessageBoxIcon messageBoxIcon = MessageBoxIcon.Warning;
+    public MessageBoxIcon MessageBoxIcon
+    {
+        get { return messageBoxIcon; }
+        set { messageBoxIcon = value; }
+    }
+
+    private class Win32Window : IWin32Window
+    {
+        private readonly IntPtr handle;
+        public Win32Window(IntPtr handle) { this.handle = handle; }
+        public IntPtr Handle { get { return handle; } }
+    }
+
+    public IObservable<TSource> Process<TSource>(IObservable<TSource> source)
+    {
+        var hwnd = System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle;
+        var owner = new Win32Window(hwnd);
+
+        var capturedText = text;
+        var capturedTitle = title;
+        var capturedIcon = messageBoxIcon;
+
+        return source.Select(value =>
+        {
+            var task = new Task(() =>
+                System.Windows.Forms.MessageBox.Show(owner, capturedText, capturedTitle, MessageBoxButtons.OK, capturedIcon));
+            task.Start();
+            return value;
+        });
+    }
+
+    public IObservable<System.Exception> Process(IObservable<System.Exception> source)
+    {
+        var hwnd = System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle;
+        var owner = new Win32Window(hwnd);
+
+        var capturedText = text;
+        var capturedTitle = title;
+        var capturedIcon = messageBoxIcon;
+
+        return source.Select(ex =>
+        {
+            var task = new Task(() =>
+                System.Windows.Forms.MessageBox.Show(owner, ex.ToString(), capturedTitle, MessageBoxButtons.OK, capturedIcon));
+            task.Start();
+            return ex;
+        });
+    }
+}

--- a/src/Extensions/ValidateClkOutput.bonsai
+++ b/src/Extensions/ValidateClkOutput.bonsai
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.9.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:p1="clr-namespace:AllenNeuralDynamics.WhiteRabbit;assembly=AllenNeuralDynamics.WhiteRabbit"
+                 xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
+                 xmlns:p2="clr-namespace:AllenNeuralDynamics.HarpUtils;assembly=AllenNeuralDynamics.HarpUtils"
+                 xmlns:p3="clr-namespace:AllenNeuralDynamics.Core;assembly=AllenNeuralDynamics.Core"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="rx:Defer">
+        <Name>ValidateClkOutput</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>RigSchema</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>HarpClockGenerator.ConnectedClockOutputs</Selector>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Merge" />
+            </Expression>
+            <Expression xsi:type="rx:ToDictionary">
+              <rx:KeySelector>OutputChannel</rx:KeySelector>
+              <rx:ElementSelector>TargetDevice</rx:ElementSelector>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Take">
+                <rx:Count>1</rx:Count>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="rx:AsyncSubject">
+              <Name>ExpectedDevices</Name>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>HarpWhiteRabbitEvents</Name>
+            </Expression>
+            <Expression xsi:type="p1:Parse">
+              <harp:Register xsi:type="p1:ConnectedDevices" />
+            </Expression>
+            <Expression xsi:type="p1:CreateMessage">
+              <harp:MessageType>Read</harp:MessageType>
+              <harp:Payload xsi:type="p1:CreateConnectedDevicesPayload">
+                <p1:ConnectedDevices>None</p1:ConnectedDevices>
+              </harp:Payload>
+            </Expression>
+            <Expression xsi:type="MulticastSubject">
+              <Name>HarpWhiteRabbitCommands</Name>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Zip" />
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Item1</Selector>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>ExpectedDevices</Name>
+            </Expression>
+            <Expression xsi:type="PropertyMapping">
+              <PropertyMappings>
+                <Property Name="ExpectedChannels" />
+              </PropertyMappings>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="p2:ValidateClkOutputChannels" />
+            </Expression>
+            <Expression xsi:type="rx:Condition">
+              <Workflow>
+                <Nodes>
+                  <Expression xsi:type="WorkflowInput">
+                    <Name>Source1</Name>
+                  </Expression>
+                  <Expression xsi:type="MemberSelector">
+                    <Selector>MissingChannels</Selector>
+                  </Expression>
+                  <Expression xsi:type="MemberSelector">
+                    <Selector>Count</Selector>
+                  </Expression>
+                  <Expression xsi:type="GreaterThan">
+                    <Operand xsi:type="IntProperty">
+                      <Value>0</Value>
+                    </Operand>
+                  </Expression>
+                  <Expression xsi:type="WorkflowOutput" />
+                </Nodes>
+                <Edges>
+                  <Edge From="0" To="1" Label="Source1" />
+                  <Edge From="1" To="2" Label="Source1" />
+                  <Edge From="2" To="3" Label="Source1" />
+                  <Edge From="3" To="4" Label="Source1" />
+                </Edges>
+              </Workflow>
+            </Expression>
+            <Expression xsi:type="Format">
+              <Format>Error raised while validating the Harp Clock Output: 
+{0}</Format>
+              <Selector>it</Selector>
+            </Expression>
+            <Expression xsi:type="InputMapping">
+              <PropertyMappings>
+                <Property Name="Message" Selector="it" />
+              </PropertyMappings>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="p3:ThrowException">
+                <p3:Message />
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="1" To="2" Label="Source1" />
+            <Edge From="2" To="3" Label="Source1" />
+            <Edge From="3" To="4" Label="Source1" />
+            <Edge From="4" To="5" Label="Source1" />
+            <Edge From="6" To="7" Label="Source1" />
+            <Edge From="7" To="10" Label="Source1" />
+            <Edge From="8" To="9" Label="Source1" />
+            <Edge From="9" To="10" Label="Source2" />
+            <Edge From="10" To="11" Label="Source1" />
+            <Edge From="11" To="14" Label="Source1" />
+            <Edge From="12" To="13" Label="Source1" />
+            <Edge From="13" To="14" Label="Source2" />
+            <Edge From="14" To="15" Label="Source1" />
+            <Edge From="15" To="16" Label="Source1" />
+            <Edge From="16" To="17" Label="Source1" />
+            <Edge From="17" To="18" Label="Source1" />
+            <Edge From="18" To="19" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/src/main.bonsai
+++ b/src/main.bonsai
@@ -395,6 +395,7 @@
           </Edges>
         </Workflow>
       </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Extensions\HardwareQA.bonsai" />
       <Expression xsi:type="Annotation">
         <Name />
         <Text><![CDATA[]]></Text>
@@ -462,22 +463,22 @@
     </Nodes>
     <Edges>
       <Edge From="0" To="1" Label="Source1" />
-      <Edge From="5" To="6" Label="Source1" />
-      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
       <Edge From="9" To="10" Label="Source1" />
       <Edge From="10" To="11" Label="Source1" />
       <Edge From="11" To="12" Label="Source1" />
       <Edge From="12" To="13" Label="Source1" />
-      <Edge From="13" To="15" Label="Source1" />
-      <Edge From="14" To="15" Label="Source2" />
-      <Edge From="16" To="19" Label="Source1" />
-      <Edge From="17" To="18" Label="Source1" />
-      <Edge From="18" To="19" Label="Source2" />
-      <Edge From="19" To="21" Label="Source1" />
-      <Edge From="20" To="21" Label="Source2" />
-      <Edge From="22" To="23" Label="Source1" />
+      <Edge From="13" To="14" Label="Source1" />
+      <Edge From="14" To="16" Label="Source1" />
+      <Edge From="15" To="16" Label="Source2" />
+      <Edge From="17" To="20" Label="Source1" />
+      <Edge From="18" To="19" Label="Source1" />
+      <Edge From="19" To="20" Label="Source2" />
+      <Edge From="20" To="22" Label="Source1" />
+      <Edge From="21" To="22" Label="Source2" />
       <Edge From="23" To="24" Label="Source1" />
       <Edge From="24" To="25" Label="Source1" />
+      <Edge From="25" To="26" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>


### PR DESCRIPTION
This PR adds online QA routines for:

- Cameras
  - If a dropped frame is detected prior to session start, it will abort the session (usually a sign of high instability and something should be checked promptly)
  - If the trigger frame rate is not compatible with the exposure, an error will be raised
  - If a dropped frame OR trigger timing mismatch is detected during a session, a warning will be raised
 
- Harp Synchronization
  - [if expected connected devices are defined ](https://github.com/AllenNeuralDynamics/Aind.Behavior.Services/blob/259ac842d917a52dc04b460f9703e4704b3a39d2/src/aind_behavior_services/rig/_harp_gen.py#L261)- It will check with the white rabbit if all those pins are connected and raise an error if one is missing along with the name of the expected device
  - The heartbeat checks are waiting for the pico core devices to implement the latest spec

- Git repository
  -  Check if the git repository is clean to ensure no experiments are run "dirty"

The checks can be disabled by setting the appropriate flags in the session model
 

