### PR TITLE
Set reward-size on each trial

### DIFF
--- a/examples/task_logic.py
+++ b/examples/task_logic.py
@@ -2,13 +2,11 @@ import os
 
 from aind_behavior_curriculum import Stage, TrainerState
 
-import aind_behavior_dynamic_foraging.task_logic as df_task_logic
 from aind_behavior_dynamic_foraging.task_logic import AindDynamicForagingTaskLogic, AindDynamicForagingTaskParameters
 
 task_logic = AindDynamicForagingTaskLogic(
     task_parameters=AindDynamicForagingTaskParameters(
         rng_seed=42,
-        reward_size=df_task_logic.RewardSize(right_value_volume=4.0, left_value_volume=4.0),
     )
 )
 

--- a/schema/aind_behavior_dynamic_foraging.json
+++ b/schema/aind_behavior_dynamic_foraging.json
@@ -3420,8 +3420,8 @@
         "reward_size": {
           "$ref": "#/$defs/RewardSize",
           "default": {
-            "right": 3.0,
-            "left": 3.0
+            "right": 2.0,
+            "left": 2.0
           },
           "description": "Parameters describing reward size."
         },

--- a/schema/aind_behavior_dynamic_foraging.json
+++ b/schema/aind_behavior_dynamic_foraging.json
@@ -199,14 +199,6 @@
           "title": "aind_behavior_services package version",
           "type": "string"
         },
-        "reward_size": {
-          "$ref": "#/$defs/RewardSize",
-          "default": {
-            "right_value_volume": 3.0,
-            "left_value_volume": 3.0
-          },
-          "description": "Parameters describing reward size."
-        },
         "trial_generator": {
           "$ref": "#/$defs/TrialGeneratorSpec",
           "default": {
@@ -440,6 +432,14 @@
           "title": "Type",
           "type": "string"
         },
+        "reward_size": {
+          "$ref": "#/$defs/RewardSize",
+          "default": {
+            "right": 3.0,
+            "left": 3.0
+          },
+          "description": "Parameters describing reward size."
+        },
         "quiescent_duration": {
           "$ref": "#/$defs/Distribution",
           "default": {
@@ -530,7 +530,8 @@
             "intervention_interval": 10,
             "maximum_water_corrections": 5,
             "bias_window_length": 200,
-            "lickspout_offset_delta": 0.05
+            "lickspout_offset_delta": 0.05,
+            "reward_fraction": 0.8
           },
           "description": "Antibias settings. If set, trial generator will give water and move lickspouts to combat bias.",
           "oneOf": [
@@ -714,6 +715,14 @@
           "minimum": 0,
           "title": "Lickspout Offset Delta",
           "type": "number"
+        },
+        "reward_fraction": {
+          "default": 0.8,
+          "description": "Fraction of full reward volume delivered for water intervention (0=none, 1=full).",
+          "maximum": 1,
+          "minimum": 0,
+          "title": "Reward Fraction",
+          "type": "number"
         }
       },
       "title": "BiasInterventionParameters",
@@ -825,6 +834,14 @@
           "title": "Type",
           "type": "string"
         },
+        "reward_size": {
+          "$ref": "#/$defs/RewardSize",
+          "default": {
+            "right": 3.0,
+            "left": 3.0
+          },
+          "description": "Parameters describing reward size."
+        },
         "quiescent_duration": {
           "$ref": "#/$defs/Distribution",
           "default": {
@@ -915,7 +932,8 @@
             "intervention_interval": 10,
             "maximum_water_corrections": 5,
             "bias_window_length": 200,
-            "lickspout_offset_delta": 0.05
+            "lickspout_offset_delta": 0.05,
+            "reward_fraction": 0.8
           },
           "description": "Antibias settings. If set, trial generator will give water and move lickspouts to combat bias.",
           "oneOf": [
@@ -1112,6 +1130,14 @@
           "title": "Type",
           "type": "string"
         },
+        "reward_size": {
+          "$ref": "#/$defs/RewardSize",
+          "default": {
+            "right": 3.0,
+            "left": 3.0
+          },
+          "description": "Parameters describing reward size."
+        },
         "quiescent_duration": {
           "$ref": "#/$defs/Distribution",
           "default": {
@@ -1202,7 +1228,8 @@
             "intervention_interval": 10,
             "maximum_water_corrections": 5,
             "bias_window_length": 200,
-            "lickspout_offset_delta": 0.05
+            "lickspout_offset_delta": 0.05,
+            "reward_fraction": 0.8
           },
           "description": "Antibias settings. If set, trial generator will give water and move lickspouts to combat bias.",
           "oneOf": [
@@ -1326,6 +1353,14 @@
           "title": "Type",
           "type": "string"
         },
+        "reward_size": {
+          "$ref": "#/$defs/RewardSize",
+          "default": {
+            "right": 3.0,
+            "left": 3.0
+          },
+          "description": "Parameters describing reward size."
+        },
         "quiescent_duration": {
           "$ref": "#/$defs/Distribution",
           "default": {
@@ -1412,7 +1447,8 @@
             "intervention_interval": 10,
             "maximum_water_corrections": 5,
             "bias_window_length": 200,
-            "lickspout_offset_delta": 0.05
+            "lickspout_offset_delta": 0.05,
+            "reward_fraction": 0.8
           },
           "description": "Antibias settings. If set, trial generator will give water and move lickspouts to combat bias.",
           "oneOf": [
@@ -2663,18 +2699,18 @@
     },
     "RewardSize": {
       "properties": {
-        "right_value_volume": {
+        "right": {
           "title": "Right reward size (uL)",
           "type": "number"
         },
-        "left_value_volume": {
+        "left": {
           "title": "Left reward size (uL)",
           "type": "number"
         }
       },
       "required": [
-        "right_value_volume",
-        "left_value_volume"
+        "right",
+        "left"
       ],
       "title": "RewardSize",
       "type": "object"
@@ -3379,6 +3415,18 @@
     "Trial": {
       "description": "Represents a single trial that can be instantiated by the Bonsai state machine.",
       "properties": {
+        "reward_size_left": {
+          "default": 1.0,
+          "minimum": 0,
+          "title": "Left reward size (uL)",
+          "type": "number"
+        },
+        "reward_size_right": {
+          "default": 1.0,
+          "minimum": 0,
+          "title": "Right reward size (uL)",
+          "type": "number"
+        },
         "p_reward_left": {
           "default": 1.0,
           "description": "The probability of reward on the left side if response is made.",
@@ -3686,6 +3734,14 @@
           "title": "Type",
           "type": "string"
         },
+        "reward_size": {
+          "$ref": "#/$defs/RewardSize",
+          "default": {
+            "right": 3.0,
+            "left": 3.0
+          },
+          "description": "Parameters describing reward size."
+        },
         "quiescent_duration": {
           "$ref": "#/$defs/Distribution",
           "default": {
@@ -3773,7 +3829,8 @@
             "intervention_interval": 10,
             "maximum_water_corrections": 5,
             "bias_window_length": 200,
-            "lickspout_offset_delta": 0.05
+            "lickspout_offset_delta": 0.05,
+            "reward_fraction": 0.8
           },
           "description": "Antibias settings. If set, trial generator will give water and move lickspouts to combat bias.",
           "oneOf": [

--- a/schema/aind_behavior_dynamic_foraging.json
+++ b/schema/aind_behavior_dynamic_foraging.json
@@ -435,8 +435,8 @@
         "reward_size": {
           "$ref": "#/$defs/RewardSize",
           "default": {
-            "right": 3.0,
-            "left": 3.0
+            "right": 2.0,
+            "left": 2.0
           },
           "description": "Parameters describing reward size."
         },
@@ -837,8 +837,8 @@
         "reward_size": {
           "$ref": "#/$defs/RewardSize",
           "default": {
-            "right": 3.0,
-            "left": 3.0
+            "right": 2.0,
+            "left": 2.0
           },
           "description": "Parameters describing reward size."
         },
@@ -1133,8 +1133,8 @@
         "reward_size": {
           "$ref": "#/$defs/RewardSize",
           "default": {
-            "right": 3.0,
-            "left": 3.0
+            "right": 2.0,
+            "left": 2.0
           },
           "description": "Parameters describing reward size."
         },
@@ -1356,8 +1356,8 @@
         "reward_size": {
           "$ref": "#/$defs/RewardSize",
           "default": {
-            "right": 3.0,
-            "left": 3.0
+            "right": 2.0,
+            "left": 2.0
           },
           "description": "Parameters describing reward size."
         },
@@ -2700,10 +2700,12 @@
     "RewardSize": {
       "properties": {
         "right": {
+          "exclusiveMinimum": 0,
           "title": "Right reward size (uL)",
           "type": "number"
         },
         "left": {
+          "exclusiveMinimum": 0,
           "title": "Left reward size (uL)",
           "type": "number"
         }
@@ -3415,17 +3417,13 @@
     "Trial": {
       "description": "Represents a single trial that can be instantiated by the Bonsai state machine.",
       "properties": {
-        "reward_size_left": {
-          "default": 1.0,
-          "minimum": 0,
-          "title": "Left reward size (uL)",
-          "type": "number"
-        },
-        "reward_size_right": {
-          "default": 1.0,
-          "minimum": 0,
-          "title": "Right reward size (uL)",
-          "type": "number"
+        "reward_size": {
+          "$ref": "#/$defs/RewardSize",
+          "default": {
+            "right": 3.0,
+            "left": 3.0
+          },
+          "description": "Parameters describing reward size."
         },
         "p_reward_left": {
           "default": 1.0,
@@ -3737,8 +3735,8 @@
         "reward_size": {
           "$ref": "#/$defs/RewardSize",
           "default": {
-            "right": 3.0,
-            "left": 3.0
+            "right": 2.0,
+            "left": 2.0
           },
           "description": "Parameters describing reward size."
         },

--- a/schema/coupled_baiting.json
+++ b/schema/coupled_baiting.json
@@ -12,15 +12,15 @@
                     "task_parameters": {
                         "rng_seed": null,
                         "aind_behavior_services_pkg_version": "0.13.5",
-                        "reward_size": {
-                            "right_value_volume": 4.0,
-                            "left_value_volume": 4.0
-                        },
                         "trial_generator": {
                             "type": "TrialGeneratorComposite",
                             "generators": [
                                 {
                                     "type": "CoupledWarmupTrialGenerator",
+                                    "reward_size": {
+                                        "right": 4.0,
+                                        "left": 4.0
+                                    },
                                     "quiescent_duration": {
                                         "family": "Scalar",
                                         "distribution_parameters": {
@@ -67,7 +67,8 @@
                                         "intervention_interval": 10,
                                         "maximum_water_corrections": 5,
                                         "bias_window_length": 200,
-                                        "lickspout_offset_delta": 0.05
+                                        "lickspout_offset_delta": 0.05,
+                                        "reward_fraction": 0.8
                                     },
                                     "is_baiting": true,
                                     "reward_probability_parameters": {
@@ -88,6 +89,10 @@
                                 },
                                 {
                                     "type": "CoupledTrialGenerator",
+                                    "reward_size": {
+                                        "right": 4.0,
+                                        "left": 4.0
+                                    },
                                     "quiescent_duration": {
                                         "family": "Scalar",
                                         "distribution_parameters": {
@@ -138,7 +143,8 @@
                                         "intervention_interval": 10,
                                         "maximum_water_corrections": 5,
                                         "bias_window_length": 200,
-                                        "lickspout_offset_delta": 0.05
+                                        "lickspout_offset_delta": 0.05,
+                                        "reward_fraction": 0.8
                                     },
                                     "is_baiting": true,
                                     "reward_probability_parameters": {
@@ -187,12 +193,12 @@
                     "task_parameters": {
                         "rng_seed": null,
                         "aind_behavior_services_pkg_version": "0.13.5",
-                        "reward_size": {
-                            "right_value_volume": 2.0,
-                            "left_value_volume": 2.0
-                        },
                         "trial_generator": {
                             "type": "CoupledTrialGenerator",
+                            "reward_size": {
+                                "right": 2.0,
+                                "left": 2.0
+                            },
                             "quiescent_duration": {
                                 "family": "Scalar",
                                 "distribution_parameters": {
@@ -243,7 +249,8 @@
                                 "intervention_interval": 10,
                                 "maximum_water_corrections": 5,
                                 "bias_window_length": 200,
-                                "lickspout_offset_delta": 0.05
+                                "lickspout_offset_delta": 0.05,
+                                "reward_fraction": 0.8
                             },
                             "is_baiting": true,
                             "reward_probability_parameters": {
@@ -290,12 +297,12 @@
                     "task_parameters": {
                         "rng_seed": null,
                         "aind_behavior_services_pkg_version": "0.13.5",
-                        "reward_size": {
-                            "right_value_volume": 2.0,
-                            "left_value_volume": 2.0
-                        },
                         "trial_generator": {
                             "type": "CoupledTrialGenerator",
+                            "reward_size": {
+                                "right": 2.0,
+                                "left": 2.0
+                            },
                             "quiescent_duration": {
                                 "family": "Scalar",
                                 "distribution_parameters": {
@@ -346,7 +353,8 @@
                                 "intervention_interval": 10,
                                 "maximum_water_corrections": 5,
                                 "bias_window_length": 200,
-                                "lickspout_offset_delta": 0.05
+                                "lickspout_offset_delta": 0.05,
+                                "reward_fraction": 0.8
                             },
                             "is_baiting": true,
                             "reward_probability_parameters": {
@@ -393,12 +401,12 @@
                     "task_parameters": {
                         "rng_seed": null,
                         "aind_behavior_services_pkg_version": "0.13.5",
-                        "reward_size": {
-                            "right_value_volume": 2.0,
-                            "left_value_volume": 2.0
-                        },
                         "trial_generator": {
                             "type": "CoupledTrialGenerator",
+                            "reward_size": {
+                                "right": 2.0,
+                                "left": 2.0
+                            },
                             "quiescent_duration": {
                                 "family": "Scalar",
                                 "distribution_parameters": {
@@ -449,7 +457,8 @@
                                 "intervention_interval": 10,
                                 "maximum_water_corrections": 5,
                                 "bias_window_length": 200,
-                                "lickspout_offset_delta": 0.05
+                                "lickspout_offset_delta": 0.05,
+                                "reward_fraction": 0.8
                             },
                             "is_baiting": true,
                             "reward_probability_parameters": {
@@ -496,12 +505,12 @@
                     "task_parameters": {
                         "rng_seed": null,
                         "aind_behavior_services_pkg_version": "0.13.5",
-                        "reward_size": {
-                            "right_value_volume": 2.0,
-                            "left_value_volume": 2.0
-                        },
                         "trial_generator": {
                             "type": "CoupledTrialGenerator",
+                            "reward_size": {
+                                "right": 2.0,
+                                "left": 2.0
+                            },
                             "quiescent_duration": {
                                 "family": "Scalar",
                                 "distribution_parameters": {
@@ -552,7 +561,8 @@
                                 "intervention_interval": 10,
                                 "maximum_water_corrections": 5,
                                 "bias_window_length": 200,
-                                "lickspout_offset_delta": 0.05
+                                "lickspout_offset_delta": 0.05,
+                                "reward_fraction": 0.8
                             },
                             "is_baiting": true,
                             "reward_probability_parameters": {
@@ -607,12 +617,12 @@
                     "task_parameters": {
                         "rng_seed": null,
                         "aind_behavior_services_pkg_version": "0.13.5",
-                        "reward_size": {
-                            "right_value_volume": 2.0,
-                            "left_value_volume": 2.0
-                        },
                         "trial_generator": {
                             "type": "CoupledTrialGenerator",
+                            "reward_size": {
+                                "right": 2.0,
+                                "left": 2.0
+                            },
                             "quiescent_duration": {
                                 "family": "Scalar",
                                 "distribution_parameters": {
@@ -663,7 +673,8 @@
                                 "intervention_interval": 10,
                                 "maximum_water_corrections": 5,
                                 "bias_window_length": 200,
-                                "lickspout_offset_delta": 0.05
+                                "lickspout_offset_delta": 0.05,
+                                "reward_fraction": 0.8
                             },
                             "is_baiting": true,
                             "reward_probability_parameters": {

--- a/schema/uncoupled.json
+++ b/schema/uncoupled.json
@@ -12,15 +12,15 @@
                     "task_parameters": {
                         "rng_seed": null,
                         "aind_behavior_services_pkg_version": "0.13.5",
-                        "reward_size": {
-                            "right_value_volume": 4.0,
-                            "left_value_volume": 4.0
-                        },
                         "trial_generator": {
                             "type": "TrialGeneratorComposite",
                             "generators": [
                                 {
                                     "type": "CoupledWarmupTrialGenerator",
+                                    "reward_size": {
+                                        "right": 4.0,
+                                        "left": 4.0
+                                    },
                                     "quiescent_duration": {
                                         "family": "Scalar",
                                         "distribution_parameters": {
@@ -67,7 +67,8 @@
                                         "intervention_interval": 10,
                                         "maximum_water_corrections": 5,
                                         "bias_window_length": 200,
-                                        "lickspout_offset_delta": 0.05
+                                        "lickspout_offset_delta": 0.05,
+                                        "reward_fraction": 0.8
                                     },
                                     "is_baiting": true,
                                     "reward_probability_parameters": {
@@ -88,6 +89,10 @@
                                 },
                                 {
                                     "type": "CoupledTrialGenerator",
+                                    "reward_size": {
+                                        "right": 4.0,
+                                        "left": 4.0
+                                    },
                                     "quiescent_duration": {
                                         "family": "Scalar",
                                         "distribution_parameters": {
@@ -138,7 +143,8 @@
                                         "intervention_interval": 10,
                                         "maximum_water_corrections": 5,
                                         "bias_window_length": 200,
-                                        "lickspout_offset_delta": 0.05
+                                        "lickspout_offset_delta": 0.05,
+                                        "reward_fraction": 0.8
                                     },
                                     "is_baiting": true,
                                     "reward_probability_parameters": {
@@ -187,12 +193,12 @@
                     "task_parameters": {
                         "rng_seed": null,
                         "aind_behavior_services_pkg_version": "0.13.5",
-                        "reward_size": {
-                            "right_value_volume": 2.0,
-                            "left_value_volume": 2.0
-                        },
                         "trial_generator": {
                             "type": "CoupledTrialGenerator",
+                            "reward_size": {
+                                "right": 2.0,
+                                "left": 2.0
+                            },
                             "quiescent_duration": {
                                 "family": "Scalar",
                                 "distribution_parameters": {
@@ -243,7 +249,8 @@
                                 "intervention_interval": 10,
                                 "maximum_water_corrections": 5,
                                 "bias_window_length": 200,
-                                "lickspout_offset_delta": 0.05
+                                "lickspout_offset_delta": 0.05,
+                                "reward_fraction": 0.8
                             },
                             "is_baiting": true,
                             "reward_probability_parameters": {
@@ -290,12 +297,12 @@
                     "task_parameters": {
                         "rng_seed": null,
                         "aind_behavior_services_pkg_version": "0.13.5",
-                        "reward_size": {
-                            "right_value_volume": 2.0,
-                            "left_value_volume": 2.0
-                        },
                         "trial_generator": {
                             "type": "CoupledTrialGenerator",
+                            "reward_size": {
+                                "right": 2.0,
+                                "left": 2.0
+                            },
                             "quiescent_duration": {
                                 "family": "Scalar",
                                 "distribution_parameters": {
@@ -346,7 +353,8 @@
                                 "intervention_interval": 10,
                                 "maximum_water_corrections": 5,
                                 "bias_window_length": 200,
-                                "lickspout_offset_delta": 0.05
+                                "lickspout_offset_delta": 0.05,
+                                "reward_fraction": 0.8
                             },
                             "is_baiting": false,
                             "reward_probability_parameters": {
@@ -393,12 +401,12 @@
                     "task_parameters": {
                         "rng_seed": null,
                         "aind_behavior_services_pkg_version": "0.13.5",
-                        "reward_size": {
-                            "right_value_volume": 2.0,
-                            "left_value_volume": 2.0
-                        },
                         "trial_generator": {
                             "type": "UncoupledTrialGenerator",
+                            "reward_size": {
+                                "right": 2.0,
+                                "left": 2.0
+                            },
                             "quiescent_duration": {
                                 "family": "Scalar",
                                 "distribution_parameters": {
@@ -446,7 +454,8 @@
                                 "intervention_interval": 10,
                                 "maximum_water_corrections": 5,
                                 "bias_window_length": 200,
-                                "lickspout_offset_delta": 0.05
+                                "lickspout_offset_delta": 0.05,
+                                "reward_fraction": 0.8
                             },
                             "is_baiting": false,
                             "trial_generation_end_parameters": {
@@ -482,12 +491,12 @@
                     "task_parameters": {
                         "rng_seed": null,
                         "aind_behavior_services_pkg_version": "0.13.5",
-                        "reward_size": {
-                            "right_value_volume": 2.0,
-                            "left_value_volume": 2.0
-                        },
                         "trial_generator": {
                             "type": "UncoupledTrialGenerator",
+                            "reward_size": {
+                                "right": 2.0,
+                                "left": 2.0
+                            },
                             "quiescent_duration": {
                                 "family": "Scalar",
                                 "distribution_parameters": {
@@ -531,7 +540,8 @@
                                 "intervention_interval": 10,
                                 "maximum_water_corrections": 5,
                                 "bias_window_length": 200,
-                                "lickspout_offset_delta": 0.05
+                                "lickspout_offset_delta": 0.05,
+                                "reward_fraction": 0.8
                             },
                             "is_baiting": false,
                             "trial_generation_end_parameters": {
@@ -567,12 +577,12 @@
                     "task_parameters": {
                         "rng_seed": null,
                         "aind_behavior_services_pkg_version": "0.13.5",
-                        "reward_size": {
-                            "right_value_volume": 2.0,
-                            "left_value_volume": 2.0
-                        },
                         "trial_generator": {
                             "type": "UncoupledTrialGenerator",
+                            "reward_size": {
+                                "right": 2.0,
+                                "left": 2.0
+                            },
                             "quiescent_duration": {
                                 "family": "Scalar",
                                 "distribution_parameters": {
@@ -616,7 +626,8 @@
                                 "intervention_interval": 10,
                                 "maximum_water_corrections": 5,
                                 "bias_window_length": 200,
-                                "lickspout_offset_delta": 0.05
+                                "lickspout_offset_delta": 0.05,
+                                "reward_fraction": 0.8
                             },
                             "is_baiting": false,
                             "trial_generation_end_parameters": {

--- a/schema/uncoupled_baiting.json
+++ b/schema/uncoupled_baiting.json
@@ -12,15 +12,15 @@
                     "task_parameters": {
                         "rng_seed": null,
                         "aind_behavior_services_pkg_version": "0.13.5",
-                        "reward_size": {
-                            "right_value_volume": 4.0,
-                            "left_value_volume": 4.0
-                        },
                         "trial_generator": {
                             "type": "TrialGeneratorComposite",
                             "generators": [
                                 {
                                     "type": "CoupledWarmupTrialGenerator",
+                                    "reward_size": {
+                                        "right": 4.0,
+                                        "left": 4.0
+                                    },
                                     "quiescent_duration": {
                                         "family": "Scalar",
                                         "distribution_parameters": {
@@ -67,7 +67,8 @@
                                         "intervention_interval": 10,
                                         "maximum_water_corrections": 5,
                                         "bias_window_length": 200,
-                                        "lickspout_offset_delta": 0.05
+                                        "lickspout_offset_delta": 0.05,
+                                        "reward_fraction": 0.8
                                     },
                                     "is_baiting": true,
                                     "reward_probability_parameters": {
@@ -88,6 +89,10 @@
                                 },
                                 {
                                     "type": "CoupledTrialGenerator",
+                                    "reward_size": {
+                                        "right": 4.0,
+                                        "left": 4.0
+                                    },
                                     "quiescent_duration": {
                                         "family": "Scalar",
                                         "distribution_parameters": {
@@ -138,7 +143,8 @@
                                         "intervention_interval": 10,
                                         "maximum_water_corrections": 5,
                                         "bias_window_length": 200,
-                                        "lickspout_offset_delta": 0.05
+                                        "lickspout_offset_delta": 0.05,
+                                        "reward_fraction": 0.8
                                     },
                                     "is_baiting": true,
                                     "reward_probability_parameters": {
@@ -187,12 +193,12 @@
                     "task_parameters": {
                         "rng_seed": null,
                         "aind_behavior_services_pkg_version": "0.13.5",
-                        "reward_size": {
-                            "right_value_volume": 2.0,
-                            "left_value_volume": 2.0
-                        },
                         "trial_generator": {
                             "type": "CoupledTrialGenerator",
+                            "reward_size": {
+                                "right": 2.0,
+                                "left": 2.0
+                            },
                             "quiescent_duration": {
                                 "family": "Scalar",
                                 "distribution_parameters": {
@@ -243,7 +249,8 @@
                                 "intervention_interval": 10,
                                 "maximum_water_corrections": 5,
                                 "bias_window_length": 200,
-                                "lickspout_offset_delta": 0.05
+                                "lickspout_offset_delta": 0.05,
+                                "reward_fraction": 0.8
                             },
                             "is_baiting": true,
                             "reward_probability_parameters": {
@@ -290,12 +297,12 @@
                     "task_parameters": {
                         "rng_seed": null,
                         "aind_behavior_services_pkg_version": "0.13.5",
-                        "reward_size": {
-                            "right_value_volume": 2.0,
-                            "left_value_volume": 2.0
-                        },
                         "trial_generator": {
                             "type": "CoupledTrialGenerator",
+                            "reward_size": {
+                                "right": 2.0,
+                                "left": 2.0
+                            },
                             "quiescent_duration": {
                                 "family": "Scalar",
                                 "distribution_parameters": {
@@ -346,7 +353,8 @@
                                 "intervention_interval": 10,
                                 "maximum_water_corrections": 5,
                                 "bias_window_length": 200,
-                                "lickspout_offset_delta": 0.05
+                                "lickspout_offset_delta": 0.05,
+                                "reward_fraction": 0.8
                             },
                             "is_baiting": true,
                             "reward_probability_parameters": {
@@ -393,12 +401,12 @@
                     "task_parameters": {
                         "rng_seed": null,
                         "aind_behavior_services_pkg_version": "0.13.5",
-                        "reward_size": {
-                            "right_value_volume": 2.0,
-                            "left_value_volume": 2.0
-                        },
                         "trial_generator": {
                             "type": "UncoupledTrialGenerator",
+                            "reward_size": {
+                                "right": 2.0,
+                                "left": 2.0
+                            },
                             "quiescent_duration": {
                                 "family": "Scalar",
                                 "distribution_parameters": {
@@ -446,7 +454,8 @@
                                 "intervention_interval": 10,
                                 "maximum_water_corrections": 5,
                                 "bias_window_length": 200,
-                                "lickspout_offset_delta": 0.05
+                                "lickspout_offset_delta": 0.05,
+                                "reward_fraction": 0.8
                             },
                             "is_baiting": true,
                             "trial_generation_end_parameters": {
@@ -482,12 +491,12 @@
                     "task_parameters": {
                         "rng_seed": null,
                         "aind_behavior_services_pkg_version": "0.13.5",
-                        "reward_size": {
-                            "right_value_volume": 2.0,
-                            "left_value_volume": 2.0
-                        },
                         "trial_generator": {
                             "type": "UncoupledTrialGenerator",
+                            "reward_size": {
+                                "right": 2.0,
+                                "left": 2.0
+                            },
                             "quiescent_duration": {
                                 "family": "Scalar",
                                 "distribution_parameters": {
@@ -535,7 +544,8 @@
                                 "intervention_interval": 10,
                                 "maximum_water_corrections": 5,
                                 "bias_window_length": 200,
-                                "lickspout_offset_delta": 0.05
+                                "lickspout_offset_delta": 0.05,
+                                "reward_fraction": 0.8
                             },
                             "is_baiting": true,
                             "trial_generation_end_parameters": {
@@ -571,12 +581,12 @@
                     "task_parameters": {
                         "rng_seed": null,
                         "aind_behavior_services_pkg_version": "0.13.5",
-                        "reward_size": {
-                            "right_value_volume": 2.0,
-                            "left_value_volume": 2.0
-                        },
                         "trial_generator": {
                             "type": "UncoupledTrialGenerator",
+                            "reward_size": {
+                                "right": 2.0,
+                                "left": 2.0
+                            },
                             "quiescent_duration": {
                                 "family": "Scalar",
                                 "distribution_parameters": {
@@ -624,7 +634,8 @@
                                 "intervention_interval": 10,
                                 "maximum_water_corrections": 5,
                                 "bias_window_length": 200,
-                                "lickspout_offset_delta": 0.05
+                                "lickspout_offset_delta": 0.05,
+                                "reward_fraction": 0.8
                             },
                             "is_baiting": true,
                             "trial_generation_end_parameters": {

--- a/src/Extensions/AindBehaviorDynamicForaging.Generated.cs
+++ b/src/Extensions/AindBehaviorDynamicForaging.Generated.cs
@@ -584,14 +584,11 @@ namespace AindDynamicForagingDataSchema
     
         private string _aindBehaviorServicesPkgVersion;
     
-        private RewardSize _rewardSize;
-    
         private TrialGeneratorSpec _trialGenerator;
     
         public AindDynamicForagingTaskParameters()
         {
             _aindBehaviorServicesPkgVersion = "0.13.5";
-            _rewardSize = new RewardSize();
             _trialGenerator = new TrialGeneratorSpec();
         }
     
@@ -599,7 +596,6 @@ namespace AindDynamicForagingDataSchema
         {
             _rngSeed = other._rngSeed;
             _aindBehaviorServicesPkgVersion = other._aindBehaviorServicesPkgVersion;
-            _rewardSize = other._rewardSize;
             _trialGenerator = other._trialGenerator;
         }
     
@@ -630,24 +626,6 @@ namespace AindDynamicForagingDataSchema
             set
             {
                 _aindBehaviorServicesPkgVersion = value;
-            }
-        }
-    
-        /// <summary>
-        /// Parameters describing reward size.
-        /// </summary>
-        [System.Xml.Serialization.XmlIgnoreAttribute()]
-        [Newtonsoft.Json.JsonPropertyAttribute("reward_size")]
-        [System.ComponentModel.DescriptionAttribute("Parameters describing reward size.")]
-        public RewardSize RewardSize
-        {
-            get
-            {
-                return _rewardSize;
-            }
-            set
-            {
-                _rewardSize = value;
             }
         }
     
@@ -683,7 +661,6 @@ namespace AindDynamicForagingDataSchema
         {
             stringBuilder.Append("RngSeed = " + _rngSeed + ", ");
             stringBuilder.Append("AindBehaviorServicesPkgVersion = " + _aindBehaviorServicesPkgVersion + ", ");
-            stringBuilder.Append("RewardSize = " + _rewardSize + ", ");
             stringBuilder.Append("TrialGenerator = " + _trialGenerator);
             return true;
         }
@@ -885,6 +862,8 @@ namespace AindDynamicForagingDataSchema
     public partial class BaseCoupledTrialGeneratorSpec : TrialGeneratorSpec
     {
     
+        private RewardSize _rewardSize;
+    
         private AllenNeuralDynamics.AindBehaviorServices.Distributions.Distribution _quiescentDuration;
     
         private double _responseDuration;
@@ -905,6 +884,7 @@ namespace AindDynamicForagingDataSchema
     
         public BaseCoupledTrialGeneratorSpec()
         {
+            _rewardSize = new RewardSize();
             _quiescentDuration = new AllenNeuralDynamics.AindBehaviorServices.Distributions.Distribution();
             _responseDuration = 1D;
             _rewardConsumptionDuration = 3D;
@@ -919,6 +899,7 @@ namespace AindDynamicForagingDataSchema
         protected BaseCoupledTrialGeneratorSpec(BaseCoupledTrialGeneratorSpec other) : 
                 base(other)
         {
+            _rewardSize = other._rewardSize;
             _quiescentDuration = other._quiescentDuration;
             _responseDuration = other._responseDuration;
             _rewardConsumptionDuration = other._rewardConsumptionDuration;
@@ -928,6 +909,24 @@ namespace AindDynamicForagingDataSchema
             _biasInterventionParameters = other._biasInterventionParameters;
             _isBaiting = other._isBaiting;
             _rewardProbabilityParameters = other._rewardProbabilityParameters;
+        }
+    
+        /// <summary>
+        /// Parameters describing reward size.
+        /// </summary>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        [Newtonsoft.Json.JsonPropertyAttribute("reward_size")]
+        [System.ComponentModel.DescriptionAttribute("Parameters describing reward size.")]
+        public RewardSize RewardSize
+        {
+            get
+            {
+                return _rewardSize;
+            }
+            set
+            {
+                _rewardSize = value;
+            }
         }
     
         /// <summary>
@@ -1109,6 +1108,7 @@ namespace AindDynamicForagingDataSchema
             {
                 stringBuilder.Append(", ");
             }
+            stringBuilder.Append("RewardSize = " + _rewardSize + ", ");
             stringBuilder.Append("QuiescentDuration = " + _quiescentDuration + ", ");
             stringBuilder.Append("ResponseDuration = " + _responseDuration + ", ");
             stringBuilder.Append("RewardConsumptionDuration = " + _rewardConsumptionDuration + ", ");
@@ -1300,6 +1300,8 @@ namespace AindDynamicForagingDataSchema
     
         private double _lickspoutOffsetDelta;
     
+        private double _rewardFraction;
+    
         public BiasInterventionParameters()
         {
             _threshold = new BiasThreshold();
@@ -1307,6 +1309,7 @@ namespace AindDynamicForagingDataSchema
             _maximumWaterCorrections = 5;
             _biasWindowLength = 200;
             _lickspoutOffsetDelta = 0.05D;
+            _rewardFraction = 0.8D;
         }
     
         protected BiasInterventionParameters(BiasInterventionParameters other)
@@ -1316,6 +1319,7 @@ namespace AindDynamicForagingDataSchema
             _maximumWaterCorrections = other._maximumWaterCorrections;
             _biasWindowLength = other._biasWindowLength;
             _lickspoutOffsetDelta = other._lickspoutOffsetDelta;
+            _rewardFraction = other._rewardFraction;
         }
     
         /// <summary>
@@ -1405,6 +1409,24 @@ namespace AindDynamicForagingDataSchema
             }
         }
     
+        /// <summary>
+        /// Fraction of full reward volume delivered for water intervention (0=none, 1=full).
+        /// </summary>
+        [Newtonsoft.Json.JsonPropertyAttribute("reward_fraction")]
+        [System.ComponentModel.DescriptionAttribute("Fraction of full reward volume delivered for water intervention (0=none, 1=full)." +
+            "")]
+        public double RewardFraction
+        {
+            get
+            {
+                return _rewardFraction;
+            }
+            set
+            {
+                _rewardFraction = value;
+            }
+        }
+    
         public System.IObservable<BiasInterventionParameters> Generate()
         {
             return System.Reactive.Linq.Observable.Defer(() => System.Reactive.Linq.Observable.Return(new BiasInterventionParameters(this)));
@@ -1421,7 +1443,8 @@ namespace AindDynamicForagingDataSchema
             stringBuilder.Append("InterventionInterval = " + _interventionInterval + ", ");
             stringBuilder.Append("MaximumWaterCorrections = " + _maximumWaterCorrections + ", ");
             stringBuilder.Append("BiasWindowLength = " + _biasWindowLength + ", ");
-            stringBuilder.Append("LickspoutOffsetDelta = " + _lickspoutOffsetDelta);
+            stringBuilder.Append("LickspoutOffsetDelta = " + _lickspoutOffsetDelta + ", ");
+            stringBuilder.Append("RewardFraction = " + _rewardFraction);
             return true;
         }
     
@@ -1534,6 +1557,8 @@ namespace AindDynamicForagingDataSchema
     public partial class BlockBasedTrialGeneratorSpec : TrialGeneratorSpec
     {
     
+        private RewardSize _rewardSize;
+    
         private AllenNeuralDynamics.AindBehaviorServices.Distributions.Distribution _quiescentDuration;
     
         private double _responseDuration;
@@ -1552,6 +1577,7 @@ namespace AindDynamicForagingDataSchema
     
         public BlockBasedTrialGeneratorSpec()
         {
+            _rewardSize = new RewardSize();
             _quiescentDuration = new AllenNeuralDynamics.AindBehaviorServices.Distributions.Distribution();
             _responseDuration = 1D;
             _rewardConsumptionDuration = 3D;
@@ -1565,6 +1591,7 @@ namespace AindDynamicForagingDataSchema
         protected BlockBasedTrialGeneratorSpec(BlockBasedTrialGeneratorSpec other) : 
                 base(other)
         {
+            _rewardSize = other._rewardSize;
             _quiescentDuration = other._quiescentDuration;
             _responseDuration = other._responseDuration;
             _rewardConsumptionDuration = other._rewardConsumptionDuration;
@@ -1573,6 +1600,24 @@ namespace AindDynamicForagingDataSchema
             _autowaterParameters = other._autowaterParameters;
             _biasInterventionParameters = other._biasInterventionParameters;
             _isBaiting = other._isBaiting;
+        }
+    
+        /// <summary>
+        /// Parameters describing reward size.
+        /// </summary>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        [Newtonsoft.Json.JsonPropertyAttribute("reward_size")]
+        [System.ComponentModel.DescriptionAttribute("Parameters describing reward size.")]
+        public RewardSize RewardSize
+        {
+            get
+            {
+                return _rewardSize;
+            }
+            set
+            {
+                _rewardSize = value;
+            }
         }
     
         /// <summary>
@@ -1736,6 +1781,7 @@ namespace AindDynamicForagingDataSchema
             {
                 stringBuilder.Append(", ");
             }
+            stringBuilder.Append("RewardSize = " + _rewardSize + ", ");
             stringBuilder.Append("QuiescentDuration = " + _quiescentDuration + ", ");
             stringBuilder.Append("ResponseDuration = " + _responseDuration + ", ");
             stringBuilder.Append("RewardConsumptionDuration = " + _rewardConsumptionDuration + ", ");
@@ -2258,6 +2304,8 @@ namespace AindDynamicForagingDataSchema
     public partial class CoupledTrialGeneratorSpec : TrialGeneratorSpec
     {
     
+        private RewardSize _rewardSize;
+    
         private AllenNeuralDynamics.AindBehaviorServices.Distributions.Distribution _quiescentDuration;
     
         private double _responseDuration;
@@ -2288,6 +2336,7 @@ namespace AindDynamicForagingDataSchema
     
         public CoupledTrialGeneratorSpec()
         {
+            _rewardSize = new RewardSize();
             _quiescentDuration = new AllenNeuralDynamics.AindBehaviorServices.Distributions.Distribution();
             _responseDuration = 1D;
             _rewardConsumptionDuration = 3D;
@@ -2307,6 +2356,7 @@ namespace AindDynamicForagingDataSchema
         protected CoupledTrialGeneratorSpec(CoupledTrialGeneratorSpec other) : 
                 base(other)
         {
+            _rewardSize = other._rewardSize;
             _quiescentDuration = other._quiescentDuration;
             _responseDuration = other._responseDuration;
             _rewardConsumptionDuration = other._rewardConsumptionDuration;
@@ -2321,6 +2371,24 @@ namespace AindDynamicForagingDataSchema
             _extendBlockOnNoResponse = other._extendBlockOnNoResponse;
             _minBlockReward = other._minBlockReward;
             _kernelSize = other._kernelSize;
+        }
+    
+        /// <summary>
+        /// Parameters describing reward size.
+        /// </summary>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        [Newtonsoft.Json.JsonPropertyAttribute("reward_size")]
+        [System.ComponentModel.DescriptionAttribute("Parameters describing reward size.")]
+        public RewardSize RewardSize
+        {
+            get
+            {
+                return _rewardSize;
+            }
+            set
+            {
+                _rewardSize = value;
+            }
         }
     
         /// <summary>
@@ -2587,6 +2655,7 @@ namespace AindDynamicForagingDataSchema
             {
                 stringBuilder.Append(", ");
             }
+            stringBuilder.Append("RewardSize = " + _rewardSize + ", ");
             stringBuilder.Append("QuiescentDuration = " + _quiescentDuration + ", ");
             stringBuilder.Append("ResponseDuration = " + _responseDuration + ", ");
             stringBuilder.Append("RewardConsumptionDuration = " + _rewardConsumptionDuration + ", ");
@@ -2744,6 +2813,8 @@ namespace AindDynamicForagingDataSchema
     public partial class CoupledWarmupTrialGeneratorSpec : TrialGeneratorSpec
     {
     
+        private RewardSize _rewardSize;
+    
         private AllenNeuralDynamics.AindBehaviorServices.Distributions.Distribution _quiescentDuration;
     
         private double _responseDuration;
@@ -2766,6 +2837,7 @@ namespace AindDynamicForagingDataSchema
     
         public CoupledWarmupTrialGeneratorSpec()
         {
+            _rewardSize = new RewardSize();
             _quiescentDuration = new AllenNeuralDynamics.AindBehaviorServices.Distributions.Distribution();
             _responseDuration = 1D;
             _rewardConsumptionDuration = 3D;
@@ -2781,6 +2853,7 @@ namespace AindDynamicForagingDataSchema
         protected CoupledWarmupTrialGeneratorSpec(CoupledWarmupTrialGeneratorSpec other) : 
                 base(other)
         {
+            _rewardSize = other._rewardSize;
             _quiescentDuration = other._quiescentDuration;
             _responseDuration = other._responseDuration;
             _rewardConsumptionDuration = other._rewardConsumptionDuration;
@@ -2791,6 +2864,24 @@ namespace AindDynamicForagingDataSchema
             _isBaiting = other._isBaiting;
             _rewardProbabilityParameters = other._rewardProbabilityParameters;
             _trialGenerationEndParameters = other._trialGenerationEndParameters;
+        }
+    
+        /// <summary>
+        /// Parameters describing reward size.
+        /// </summary>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        [Newtonsoft.Json.JsonPropertyAttribute("reward_size")]
+        [System.ComponentModel.DescriptionAttribute("Parameters describing reward size.")]
+        public RewardSize RewardSize
+        {
+            get
+            {
+                return _rewardSize;
+            }
+            set
+            {
+                _rewardSize = value;
+            }
         }
     
         /// <summary>
@@ -2989,6 +3080,7 @@ namespace AindDynamicForagingDataSchema
             {
                 stringBuilder.Append(", ");
             }
+            stringBuilder.Append("RewardSize = " + _rewardSize + ", ");
             stringBuilder.Append("QuiescentDuration = " + _quiescentDuration + ", ");
             stringBuilder.Append("ResponseDuration = " + _responseDuration + ", ");
             stringBuilder.Append("RewardConsumptionDuration = " + _rewardConsumptionDuration + ", ");
@@ -4721,9 +4813,9 @@ namespace AindDynamicForagingDataSchema
     public partial class RewardSize
     {
     
-        private double _rightValueVolume;
+        private double _right;
     
-        private double _leftValueVolume;
+        private double _left;
     
         public RewardSize()
         {
@@ -4731,33 +4823,33 @@ namespace AindDynamicForagingDataSchema
     
         protected RewardSize(RewardSize other)
         {
-            _rightValueVolume = other._rightValueVolume;
-            _leftValueVolume = other._leftValueVolume;
+            _right = other._right;
+            _left = other._left;
         }
     
-        [Newtonsoft.Json.JsonPropertyAttribute("right_value_volume", Required=Newtonsoft.Json.Required.Always)]
-        public double RightValueVolume
+        [Newtonsoft.Json.JsonPropertyAttribute("right", Required=Newtonsoft.Json.Required.Always)]
+        public double Right
         {
             get
             {
-                return _rightValueVolume;
+                return _right;
             }
             set
             {
-                _rightValueVolume = value;
+                _right = value;
             }
         }
     
-        [Newtonsoft.Json.JsonPropertyAttribute("left_value_volume", Required=Newtonsoft.Json.Required.Always)]
-        public double LeftValueVolume
+        [Newtonsoft.Json.JsonPropertyAttribute("left", Required=Newtonsoft.Json.Required.Always)]
+        public double Left
         {
             get
             {
-                return _leftValueVolume;
+                return _left;
             }
             set
             {
-                _leftValueVolume = value;
+                _left = value;
             }
         }
     
@@ -4773,8 +4865,8 @@ namespace AindDynamicForagingDataSchema
     
         protected virtual bool PrintMembers(System.Text.StringBuilder stringBuilder)
         {
-            stringBuilder.Append("RightValueVolume = " + _rightValueVolume + ", ");
-            stringBuilder.Append("LeftValueVolume = " + _leftValueVolume);
+            stringBuilder.Append("Right = " + _right + ", ");
+            stringBuilder.Append("Left = " + _left);
             return true;
         }
     
@@ -6073,6 +6165,10 @@ namespace AindDynamicForagingDataSchema
     public partial class Trial
     {
     
+        private double _rewardSizeLeft;
+    
+        private double _rewardSizeRight;
+    
         private double _pRewardLeft;
     
         private double _pRewardRight;
@@ -6099,6 +6195,8 @@ namespace AindDynamicForagingDataSchema
     
         public Trial()
         {
+            _rewardSizeLeft = 1D;
+            _rewardSizeRight = 1D;
             _pRewardLeft = 1D;
             _pRewardRight = 1D;
             _rewardConsumptionDuration = 5D;
@@ -6111,6 +6209,8 @@ namespace AindDynamicForagingDataSchema
     
         protected Trial(Trial other)
         {
+            _rewardSizeLeft = other._rewardSizeLeft;
+            _rewardSizeRight = other._rewardSizeRight;
             _pRewardLeft = other._pRewardLeft;
             _pRewardRight = other._pRewardRight;
             _rewardConsumptionDuration = other._rewardConsumptionDuration;
@@ -6123,6 +6223,32 @@ namespace AindDynamicForagingDataSchema
             _isAutoRewardRight = other._isAutoRewardRight;
             _lickspoutOffsetDelta = other._lickspoutOffsetDelta;
             _metadata = other._metadata;
+        }
+    
+        [Newtonsoft.Json.JsonPropertyAttribute("reward_size_left")]
+        public double RewardSizeLeft
+        {
+            get
+            {
+                return _rewardSizeLeft;
+            }
+            set
+            {
+                _rewardSizeLeft = value;
+            }
+        }
+    
+        [Newtonsoft.Json.JsonPropertyAttribute("reward_size_right")]
+        public double RewardSizeRight
+        {
+            get
+            {
+                return _rewardSizeRight;
+            }
+            set
+            {
+                _rewardSizeRight = value;
+            }
         }
     
         /// <summary>
@@ -6348,6 +6474,8 @@ namespace AindDynamicForagingDataSchema
     
         protected virtual bool PrintMembers(System.Text.StringBuilder stringBuilder)
         {
+            stringBuilder.Append("RewardSizeLeft = " + _rewardSizeLeft + ", ");
+            stringBuilder.Append("RewardSizeRight = " + _rewardSizeRight + ", ");
             stringBuilder.Append("PRewardLeft = " + _pRewardLeft + ", ");
             stringBuilder.Append("PRewardRight = " + _pRewardRight + ", ");
             stringBuilder.Append("RewardConsumptionDuration = " + _rewardConsumptionDuration + ", ");
@@ -6878,6 +7006,8 @@ namespace AindDynamicForagingDataSchema
     public partial class UncoupledTrialGeneratorSpec : TrialGeneratorSpec
     {
     
+        private RewardSize _rewardSize;
+    
         private AllenNeuralDynamics.AindBehaviorServices.Distributions.Distribution _quiescentDuration;
     
         private double _responseDuration;
@@ -6902,6 +7032,7 @@ namespace AindDynamicForagingDataSchema
     
         public UncoupledTrialGeneratorSpec()
         {
+            _rewardSize = new RewardSize();
             _quiescentDuration = new AllenNeuralDynamics.AindBehaviorServices.Distributions.Distribution();
             _responseDuration = 1D;
             _rewardConsumptionDuration = 3D;
@@ -6918,6 +7049,7 @@ namespace AindDynamicForagingDataSchema
         protected UncoupledTrialGeneratorSpec(UncoupledTrialGeneratorSpec other) : 
                 base(other)
         {
+            _rewardSize = other._rewardSize;
             _quiescentDuration = other._quiescentDuration;
             _responseDuration = other._responseDuration;
             _rewardConsumptionDuration = other._rewardConsumptionDuration;
@@ -6929,6 +7061,24 @@ namespace AindDynamicForagingDataSchema
             _trialGenerationEndParameters = other._trialGenerationEndParameters;
             _rewardProbabilities = other._rewardProbabilities;
             _maximumDominanceStreak = other._maximumDominanceStreak;
+        }
+    
+        /// <summary>
+        /// Parameters describing reward size.
+        /// </summary>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        [Newtonsoft.Json.JsonPropertyAttribute("reward_size")]
+        [System.ComponentModel.DescriptionAttribute("Parameters describing reward size.")]
+        public RewardSize RewardSize
+        {
+            get
+            {
+                return _rewardSize;
+            }
+            set
+            {
+                _rewardSize = value;
+            }
         }
     
         /// <summary>
@@ -7145,6 +7295,7 @@ namespace AindDynamicForagingDataSchema
             {
                 stringBuilder.Append(", ");
             }
+            stringBuilder.Append("RewardSize = " + _rewardSize + ", ");
             stringBuilder.Append("QuiescentDuration = " + _quiescentDuration + ", ");
             stringBuilder.Append("ResponseDuration = " + _responseDuration + ", ");
             stringBuilder.Append("RewardConsumptionDuration = " + _rewardConsumptionDuration + ", ");

--- a/src/Extensions/AindBehaviorDynamicForaging.Generated.cs
+++ b/src/Extensions/AindBehaviorDynamicForaging.Generated.cs
@@ -6165,9 +6165,7 @@ namespace AindDynamicForagingDataSchema
     public partial class Trial
     {
     
-        private double _rewardSizeLeft;
-    
-        private double _rewardSizeRight;
+        private RewardSize _rewardSize;
     
         private double _pRewardLeft;
     
@@ -6195,8 +6193,7 @@ namespace AindDynamicForagingDataSchema
     
         public Trial()
         {
-            _rewardSizeLeft = 1D;
-            _rewardSizeRight = 1D;
+            _rewardSize = new RewardSize();
             _pRewardLeft = 1D;
             _pRewardRight = 1D;
             _rewardConsumptionDuration = 5D;
@@ -6209,8 +6206,7 @@ namespace AindDynamicForagingDataSchema
     
         protected Trial(Trial other)
         {
-            _rewardSizeLeft = other._rewardSizeLeft;
-            _rewardSizeRight = other._rewardSizeRight;
+            _rewardSize = other._rewardSize;
             _pRewardLeft = other._pRewardLeft;
             _pRewardRight = other._pRewardRight;
             _rewardConsumptionDuration = other._rewardConsumptionDuration;
@@ -6225,29 +6221,21 @@ namespace AindDynamicForagingDataSchema
             _metadata = other._metadata;
         }
     
-        [Newtonsoft.Json.JsonPropertyAttribute("reward_size_left")]
-        public double RewardSizeLeft
+        /// <summary>
+        /// Parameters describing reward size.
+        /// </summary>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        [Newtonsoft.Json.JsonPropertyAttribute("reward_size")]
+        [System.ComponentModel.DescriptionAttribute("Parameters describing reward size.")]
+        public RewardSize RewardSize
         {
             get
             {
-                return _rewardSizeLeft;
+                return _rewardSize;
             }
             set
             {
-                _rewardSizeLeft = value;
-            }
-        }
-    
-        [Newtonsoft.Json.JsonPropertyAttribute("reward_size_right")]
-        public double RewardSizeRight
-        {
-            get
-            {
-                return _rewardSizeRight;
-            }
-            set
-            {
-                _rewardSizeRight = value;
+                _rewardSize = value;
             }
         }
     
@@ -6474,8 +6462,7 @@ namespace AindDynamicForagingDataSchema
     
         protected virtual bool PrintMembers(System.Text.StringBuilder stringBuilder)
         {
-            stringBuilder.Append("RewardSizeLeft = " + _rewardSizeLeft + ", ");
-            stringBuilder.Append("RewardSizeRight = " + _rewardSizeRight + ", ");
+            stringBuilder.Append("RewardSize = " + _rewardSize + ", ");
             stringBuilder.Append("PRewardLeft = " + _pRewardLeft + ", ");
             stringBuilder.Append("PRewardRight = " + _pRewardRight + ", ");
             stringBuilder.Append("RewardConsumptionDuration = " + _rewardConsumptionDuration + ", ");

--- a/src/Extensions/OperationControl.bonsai
+++ b/src/Extensions/OperationControl.bonsai
@@ -511,6 +511,9 @@
                   <Expression xsi:type="MemberSelector">
                     <Selector>Item2</Selector>
                   </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:DistinctUntilChanged" />
+                  </Expression>
                   <Expression xsi:type="beh:Format">
                     <harp:MessageType>Write</harp:MessageType>
                     <harp:Register xsi:type="beh:PulseSupplyPort1" />
@@ -538,15 +541,15 @@
                   <Expression xsi:type="MemberSelector">
                     <Selector>Item2</Selector>
                   </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:DistinctUntilChanged" />
+                  </Expression>
                   <Expression xsi:type="beh:Format">
                     <harp:MessageType>Write</harp:MessageType>
                     <harp:Register xsi:type="beh:PulseSupplyPort0" />
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="rx:Merge" />
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="rx:DistinctUntilChanged" />
                   </Expression>
                   <Expression xsi:type="MulticastSubject">
                     <Name>HarpBehaviorCommands</Name>
@@ -579,15 +582,16 @@
                   <Edge From="22" To="23" Label="Source1" />
                   <Edge From="24" To="25" Label="Source1" />
                   <Edge From="25" To="26" Label="Source1" />
-                  <Edge From="25" To="29" Label="Source1" />
+                  <Edge From="25" To="30" Label="Source1" />
                   <Edge From="26" To="27" Label="Source1" />
                   <Edge From="27" To="28" Label="Source1" />
-                  <Edge From="28" To="32" Label="Source1" />
-                  <Edge From="29" To="30" Label="Source1" />
+                  <Edge From="28" To="29" Label="Source1" />
+                  <Edge From="29" To="34" Label="Source1" />
                   <Edge From="30" To="31" Label="Source1" />
-                  <Edge From="31" To="32" Label="Source2" />
+                  <Edge From="31" To="32" Label="Source1" />
                   <Edge From="32" To="33" Label="Source1" />
-                  <Edge From="33" To="34" Label="Source1" />
+                  <Edge From="33" To="34" Label="Source2" />
+                  <Edge From="34" To="35" Label="Source1" />
                 </Edges>
               </Workflow>
             </Expression>

--- a/src/Extensions/OperationControl.bonsai
+++ b/src/Extensions/OperationControl.bonsai
@@ -545,6 +545,9 @@
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="rx:Merge" />
                   </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:DistinctUntilChanged" />
+                  </Expression>
                   <Expression xsi:type="MulticastSubject">
                     <Name>HarpBehaviorCommands</Name>
                   </Expression>
@@ -584,6 +587,7 @@
                   <Edge From="30" To="31" Label="Source1" />
                   <Edge From="31" To="32" Label="Source2" />
                   <Edge From="32" To="33" Label="Source1" />
+                  <Edge From="33" To="34" Label="Source1" />
                 </Edges>
               </Workflow>
             </Expression>

--- a/src/Extensions/TaskEngine.bonsai
+++ b/src/Extensions/TaskEngine.bonsai
@@ -760,7 +760,7 @@
                                 <Name>ThisTrial</Name>
                               </Expression>
                               <Expression xsi:type="MemberSelector">
-                                <Selector>RewardRightSize</Selector>
+                                <Selector>RewardSizeRight</Selector>
                               </Expression>
                               <Expression xsi:type="Combinator">
                                 <Combinator xsi:type="rx:Zip" />
@@ -792,7 +792,7 @@
                                 <Name>ThisTrial</Name>
                               </Expression>
                               <Expression xsi:type="MemberSelector">
-                                <Selector>RewardRightSize</Selector>
+                                <Selector>RewardSizeLeft</Selector>
                               </Expression>
                               <Expression xsi:type="Combinator">
                                 <Combinator xsi:type="rx:Zip" />

--- a/src/Extensions/TaskEngine.bonsai
+++ b/src/Extensions/TaskEngine.bonsai
@@ -747,6 +747,70 @@
                         <Expression xsi:type="rx:AsyncSubject">
                           <Name>response</Name>
                         </Expression>
+                        <Expression xsi:type="GroupWorkflow">
+                          <Name>SetRightRewardSize</Name>
+                          <Workflow>
+                            <Nodes>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="BooleanProperty">
+                                  <Value>true</Value>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="SubscribeSubject">
+                                <Name>ThisTrial</Name>
+                              </Expression>
+                              <Expression xsi:type="MemberSelector">
+                                <Selector>RewardRightSize</Selector>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:Zip" />
+                              </Expression>
+                              <Expression xsi:type="MulticastSubject">
+                                <Name>SetIsRightRewardAmount</Name>
+                              </Expression>
+                              <Expression xsi:type="WorkflowOutput" />
+                            </Nodes>
+                            <Edges>
+                              <Edge From="0" To="3" Label="Source1" />
+                              <Edge From="1" To="2" Label="Source1" />
+                              <Edge From="2" To="3" Label="Source2" />
+                              <Edge From="3" To="4" Label="Source1" />
+                              <Edge From="4" To="5" Label="Source1" />
+                            </Edges>
+                          </Workflow>
+                        </Expression>
+                        <Expression xsi:type="GroupWorkflow">
+                          <Name>SetLeftRewardSize</Name>
+                          <Workflow>
+                            <Nodes>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="BooleanProperty">
+                                  <Value>false</Value>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="SubscribeSubject">
+                                <Name>ThisTrial</Name>
+                              </Expression>
+                              <Expression xsi:type="MemberSelector">
+                                <Selector>RewardRightSize</Selector>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:Zip" />
+                              </Expression>
+                              <Expression xsi:type="MulticastSubject">
+                                <Name>SetIsRightRewardAmount</Name>
+                              </Expression>
+                              <Expression xsi:type="WorkflowOutput" />
+                            </Nodes>
+                            <Edges>
+                              <Edge From="0" To="3" Label="Source1" />
+                              <Edge From="1" To="2" Label="Source1" />
+                              <Edge From="2" To="3" Label="Source2" />
+                              <Edge From="3" To="4" Label="Source1" />
+                              <Edge From="4" To="5" Label="Source1" />
+                            </Edges>
+                          </Workflow>
+                        </Expression>
                         <Expression xsi:type="SubscribeSubject">
                           <Name>response</Name>
                         </Expression>
@@ -779,14 +843,14 @@
                       <Edges>
                         <Edge From="0" To="1" Label="Source1" />
                         <Edge From="1" To="2" Label="Source1" />
-                        <Edge From="3" To="4" Label="Source1" />
-                        <Edge From="4" To="6" Label="Source1" />
-                        <Edge From="5" To="6" Label="Source2" />
-                        <Edge From="6" To="7" Label="Source1" />
-                        <Edge From="7" To="9" Label="Source1" />
-                        <Edge From="8" To="9" Label="Source2" />
-                        <Edge From="9" To="10" Label="Source1" />
-                        <Edge From="10" To="11" Label="Source1" />
+                        <Edge From="5" To="6" Label="Source1" />
+                        <Edge From="6" To="8" Label="Source1" />
+                        <Edge From="7" To="8" Label="Source2" />
+                        <Edge From="8" To="9" Label="Source1" />
+                        <Edge From="9" To="11" Label="Source1" />
+                        <Edge From="10" To="11" Label="Source2" />
+                        <Edge From="11" To="12" Label="Source1" />
+                        <Edge From="12" To="13" Label="Source1" />
                       </Edges>
                     </Workflow>
                   </Expression>

--- a/src/Extensions/TaskEngine.bonsai
+++ b/src/Extensions/TaskEngine.bonsai
@@ -26,6 +26,78 @@
             <Expression xsi:type="MulticastSubject">
               <Name>GlobalTrial</Name>
             </Expression>
+            <Expression xsi:type="GroupWorkflow">
+              <Name>SetLeftRewardSize</Name>
+              <Workflow>
+                <Nodes>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="BooleanProperty">
+                      <Value>false</Value>
+                    </Combinator>
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>ThisTrial</Name>
+                  </Expression>
+                  <Expression xsi:type="MemberSelector">
+                    <Selector>RewardSize.Left</Selector>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:Zip" />
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:DistinctUntilChanged" />
+                  </Expression>
+                  <Expression xsi:type="MulticastSubject">
+                    <Name>SetIsRightRewardAmount</Name>
+                  </Expression>
+                  <Expression xsi:type="WorkflowOutput" />
+                </Nodes>
+                <Edges>
+                  <Edge From="0" To="3" Label="Source1" />
+                  <Edge From="1" To="2" Label="Source1" />
+                  <Edge From="2" To="3" Label="Source2" />
+                  <Edge From="3" To="4" Label="Source1" />
+                  <Edge From="4" To="5" Label="Source1" />
+                  <Edge From="5" To="6" Label="Source1" />
+                </Edges>
+              </Workflow>
+            </Expression>
+            <Expression xsi:type="GroupWorkflow">
+              <Name>SetRightRewardSize</Name>
+              <Workflow>
+                <Nodes>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="BooleanProperty">
+                      <Value>true</Value>
+                    </Combinator>
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>ThisTrial</Name>
+                  </Expression>
+                  <Expression xsi:type="MemberSelector">
+                    <Selector>RewardSize.Right</Selector>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:Zip" />
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:DistinctUntilChanged" />
+                  </Expression>
+                  <Expression xsi:type="MulticastSubject">
+                    <Name>SetIsRightRewardAmount</Name>
+                  </Expression>
+                  <Expression xsi:type="WorkflowOutput" />
+                </Nodes>
+                <Edges>
+                  <Edge From="0" To="3" Label="Source1" />
+                  <Edge From="1" To="2" Label="Source1" />
+                  <Edge From="2" To="3" Label="Source2" />
+                  <Edge From="3" To="4" Label="Source1" />
+                  <Edge From="4" To="5" Label="Source1" />
+                  <Edge From="5" To="6" Label="Source1" />
+                </Edges>
+              </Workflow>
+            </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="py:GetRuntime" />
             </Expression>
@@ -1601,28 +1673,28 @@
           <Edges>
             <Edge From="1" To="2" Label="Source1" />
             <Edge From="2" To="3" Label="Source1" />
-            <Edge From="4" To="5" Label="Source1" />
-            <Edge From="5" To="6" Label="Source1" />
-            <Edge From="6" To="11" Label="Source1" />
+            <Edge From="6" To="7" Label="Source1" />
             <Edge From="7" To="8" Label="Source1" />
-            <Edge From="8" To="9" Label="Source1" />
+            <Edge From="8" To="13" Label="Source1" />
             <Edge From="9" To="10" Label="Source1" />
-            <Edge From="10" To="11" Label="Source2" />
+            <Edge From="10" To="11" Label="Source1" />
             <Edge From="11" To="12" Label="Source1" />
-            <Edge From="12" To="13" Label="Source1" />
+            <Edge From="12" To="13" Label="Source2" />
             <Edge From="13" To="14" Label="Source1" />
             <Edge From="14" To="15" Label="Source1" />
-            <Edge From="15" To="18" Label="Source1" />
+            <Edge From="15" To="16" Label="Source1" />
             <Edge From="16" To="17" Label="Source1" />
-            <Edge From="17" To="18" Label="Source2" />
+            <Edge From="17" To="20" Label="Source1" />
             <Edge From="18" To="19" Label="Source1" />
-            <Edge From="19" To="20" Label="Source1" />
+            <Edge From="19" To="20" Label="Source2" />
             <Edge From="20" To="21" Label="Source1" />
+            <Edge From="21" To="22" Label="Source1" />
             <Edge From="22" To="23" Label="Source1" />
-            <Edge From="23" To="24" Label="Source1" />
             <Edge From="24" To="25" Label="Source1" />
             <Edge From="25" To="26" Label="Source1" />
             <Edge From="26" To="27" Label="Source1" />
+            <Edge From="27" To="28" Label="Source1" />
+            <Edge From="28" To="29" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>

--- a/src/Extensions/TaskEngine.bonsai
+++ b/src/Extensions/TaskEngine.bonsai
@@ -747,70 +747,6 @@
                         <Expression xsi:type="rx:AsyncSubject">
                           <Name>response</Name>
                         </Expression>
-                        <Expression xsi:type="GroupWorkflow">
-                          <Name>SetRightRewardSize</Name>
-                          <Workflow>
-                            <Nodes>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="BooleanProperty">
-                                  <Value>true</Value>
-                                </Combinator>
-                              </Expression>
-                              <Expression xsi:type="SubscribeSubject">
-                                <Name>ThisTrial</Name>
-                              </Expression>
-                              <Expression xsi:type="MemberSelector">
-                                <Selector>RewardSizeRight</Selector>
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="rx:Zip" />
-                              </Expression>
-                              <Expression xsi:type="MulticastSubject">
-                                <Name>SetIsRightRewardAmount</Name>
-                              </Expression>
-                              <Expression xsi:type="WorkflowOutput" />
-                            </Nodes>
-                            <Edges>
-                              <Edge From="0" To="3" Label="Source1" />
-                              <Edge From="1" To="2" Label="Source1" />
-                              <Edge From="2" To="3" Label="Source2" />
-                              <Edge From="3" To="4" Label="Source1" />
-                              <Edge From="4" To="5" Label="Source1" />
-                            </Edges>
-                          </Workflow>
-                        </Expression>
-                        <Expression xsi:type="GroupWorkflow">
-                          <Name>SetLeftRewardSize</Name>
-                          <Workflow>
-                            <Nodes>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="BooleanProperty">
-                                  <Value>false</Value>
-                                </Combinator>
-                              </Expression>
-                              <Expression xsi:type="SubscribeSubject">
-                                <Name>ThisTrial</Name>
-                              </Expression>
-                              <Expression xsi:type="MemberSelector">
-                                <Selector>RewardSizeLeft</Selector>
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="rx:Zip" />
-                              </Expression>
-                              <Expression xsi:type="MulticastSubject">
-                                <Name>SetIsRightRewardAmount</Name>
-                              </Expression>
-                              <Expression xsi:type="WorkflowOutput" />
-                            </Nodes>
-                            <Edges>
-                              <Edge From="0" To="3" Label="Source1" />
-                              <Edge From="1" To="2" Label="Source1" />
-                              <Edge From="2" To="3" Label="Source2" />
-                              <Edge From="3" To="4" Label="Source1" />
-                              <Edge From="4" To="5" Label="Source1" />
-                            </Edges>
-                          </Workflow>
-                        </Expression>
                         <Expression xsi:type="SubscribeSubject">
                           <Name>response</Name>
                         </Expression>
@@ -843,14 +779,14 @@
                       <Edges>
                         <Edge From="0" To="1" Label="Source1" />
                         <Edge From="1" To="2" Label="Source1" />
-                        <Edge From="5" To="6" Label="Source1" />
-                        <Edge From="6" To="8" Label="Source1" />
-                        <Edge From="7" To="8" Label="Source2" />
-                        <Edge From="8" To="9" Label="Source1" />
-                        <Edge From="9" To="11" Label="Source1" />
-                        <Edge From="10" To="11" Label="Source2" />
-                        <Edge From="11" To="12" Label="Source1" />
-                        <Edge From="12" To="13" Label="Source1" />
+                        <Edge From="3" To="4" Label="Source1" />
+                        <Edge From="4" To="6" Label="Source1" />
+                        <Edge From="5" To="6" Label="Source2" />
+                        <Edge From="6" To="7" Label="Source1" />
+                        <Edge From="7" To="9" Label="Source1" />
+                        <Edge From="8" To="9" Label="Source2" />
+                        <Edge From="9" To="10" Label="Source1" />
+                        <Edge From="10" To="11" Label="Source1" />
                       </Edges>
                     </Workflow>
                   </Expression>
@@ -1229,30 +1165,6 @@
                         <Expression xsi:type="rx:AsyncSubject">
                           <Name>thisTrialOutcome</Name>
                         </Expression>
-                        <Expression xsi:type="SubscribeSubject">
-                          <Name>ThisTrial</Name>
-                        </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:Take">
-                            <rx:Count>1</rx:Count>
-                          </Combinator>
-                        </Expression>
-                        <Expression xsi:type="MemberSelector">
-                          <Selector>InterTrialIntervalDuration</Selector>
-                        </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="p3:TimeSpanFromSeconds" />
-                        </Expression>
-                        <Expression xsi:type="PropertyMapping">
-                          <PropertyMappings>
-                            <Property Name="DueTime" />
-                          </PropertyMappings>
-                        </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:Timer">
-                            <rx:DueTime>PT5S</rx:DueTime>
-                          </Combinator>
-                        </Expression>
                         <Expression xsi:type="GroupWorkflow">
                           <Name>SampleNextTrial</Name>
                           <Workflow>
@@ -1375,6 +1287,108 @@
                               <Edge From="9" To="10" Label="Source1" />
                             </Edges>
                           </Workflow>
+                        </Expression>
+                        <Expression xsi:type="rx:BehaviorSubject">
+                          <Name>NextTrial</Name>
+                        </Expression>
+                        <Expression xsi:type="GroupWorkflow">
+                          <Name>SetLeftRewardSize</Name>
+                          <Workflow>
+                            <Nodes>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="BooleanProperty">
+                                  <Value>false</Value>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="SubscribeSubject">
+                                <Name>NextTrial</Name>
+                              </Expression>
+                              <Expression xsi:type="MemberSelector">
+                                <Selector>RewardSize.Left</Selector>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:Zip" />
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:DistinctUntilChanged" />
+                              </Expression>
+                              <Expression xsi:type="MulticastSubject">
+                                <Name>SetIsRightRewardAmount</Name>
+                              </Expression>
+                              <Expression xsi:type="WorkflowOutput" />
+                            </Nodes>
+                            <Edges>
+                              <Edge From="0" To="3" Label="Source1" />
+                              <Edge From="1" To="2" Label="Source1" />
+                              <Edge From="2" To="3" Label="Source2" />
+                              <Edge From="3" To="4" Label="Source1" />
+                              <Edge From="4" To="5" Label="Source1" />
+                              <Edge From="5" To="6" Label="Source1" />
+                            </Edges>
+                          </Workflow>
+                        </Expression>
+                        <Expression xsi:type="GroupWorkflow">
+                          <Name>SetRightRewardSize</Name>
+                          <Workflow>
+                            <Nodes>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="BooleanProperty">
+                                  <Value>true</Value>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="SubscribeSubject">
+                                <Name>NextTrial</Name>
+                              </Expression>
+                              <Expression xsi:type="MemberSelector">
+                                <Selector>RewardSize.Right</Selector>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:Zip" />
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:DistinctUntilChanged" />
+                              </Expression>
+                              <Expression xsi:type="MulticastSubject">
+                                <Name>SetIsRightRewardAmount</Name>
+                              </Expression>
+                              <Expression xsi:type="WorkflowOutput" />
+                            </Nodes>
+                            <Edges>
+                              <Edge From="0" To="3" Label="Source1" />
+                              <Edge From="1" To="2" Label="Source1" />
+                              <Edge From="2" To="3" Label="Source2" />
+                              <Edge From="3" To="4" Label="Source1" />
+                              <Edge From="4" To="5" Label="Source1" />
+                              <Edge From="5" To="6" Label="Source1" />
+                            </Edges>
+                          </Workflow>
+                        </Expression>
+                        <Expression xsi:type="SubscribeSubject">
+                          <Name>ThisTrial</Name>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="rx:Take">
+                            <rx:Count>1</rx:Count>
+                          </Combinator>
+                        </Expression>
+                        <Expression xsi:type="MemberSelector">
+                          <Selector>InterTrialIntervalDuration</Selector>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="p3:TimeSpanFromSeconds" />
+                        </Expression>
+                        <Expression xsi:type="PropertyMapping">
+                          <PropertyMappings>
+                            <Property Name="DueTime" />
+                          </PropertyMappings>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="rx:Timer">
+                            <rx:DueTime>PT5S</rx:DueTime>
+                          </Combinator>
+                        </Expression>
+                        <Expression xsi:type="SubscribeSubject">
+                          <Name>NextTrial</Name>
                         </Expression>
                         <Expression xsi:type="SubscribeSubject">
                           <Name>GlobalAutoWaterState</Name>
@@ -1516,29 +1530,30 @@
                         <Edge From="11" To="12" Label="Source1" />
                         <Edge From="12" To="13" Label="Source1" />
                         <Edge From="14" To="15" Label="Source1" />
-                        <Edge From="15" To="16" Label="Source1" />
-                        <Edge From="16" To="17" Label="Source1" />
-                        <Edge From="17" To="18" Label="Source1" />
                         <Edge From="18" To="19" Label="Source1" />
-                        <Edge From="19" To="28" Label="Source1" />
-                        <Edge From="20" To="23" Label="Source1" />
+                        <Edge From="19" To="20" Label="Source1" />
+                        <Edge From="20" To="21" Label="Source1" />
                         <Edge From="21" To="22" Label="Source1" />
-                        <Edge From="22" To="23" Label="Source2" />
-                        <Edge From="23" To="24" Label="Source1" />
-                        <Edge From="24" To="25" Label="Source1" />
+                        <Edge From="22" To="23" Label="Source1" />
+                        <Edge From="23" To="32" Label="Source1" />
+                        <Edge From="24" To="27" Label="Source1" />
                         <Edge From="25" To="26" Label="Source1" />
-                        <Edge From="26" To="28" Label="Source2" />
-                        <Edge From="27" To="28" Label="Source3" />
+                        <Edge From="26" To="27" Label="Source2" />
+                        <Edge From="27" To="28" Label="Source1" />
                         <Edge From="28" To="29" Label="Source1" />
                         <Edge From="29" To="30" Label="Source1" />
-                        <Edge From="30" To="31" Label="Source1" />
+                        <Edge From="30" To="32" Label="Source2" />
+                        <Edge From="31" To="32" Label="Source3" />
                         <Edge From="32" To="33" Label="Source1" />
                         <Edge From="33" To="34" Label="Source1" />
                         <Edge From="34" To="35" Label="Source1" />
-                        <Edge From="35" To="36" Label="Source1" />
                         <Edge From="36" To="37" Label="Source1" />
+                        <Edge From="37" To="38" Label="Source1" />
                         <Edge From="38" To="39" Label="Source1" />
                         <Edge From="39" To="40" Label="Source1" />
+                        <Edge From="40" To="41" Label="Source1" />
+                        <Edge From="42" To="43" Label="Source1" />
+                        <Edge From="43" To="44" Label="Source1" />
                       </Edges>
                     </Workflow>
                   </Expression>

--- a/src/Extensions/TaskEngine.bonsai
+++ b/src/Extensions/TaskEngine.bonsai
@@ -185,9 +185,6 @@
                         <Expression xsi:type="Combinator">
                           <Combinator xsi:type="rx:Zip" />
                         </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:DistinctUntilChanged" />
-                        </Expression>
                         <Expression xsi:type="MulticastSubject">
                           <Name>SetIsRightRewardAmount</Name>
                         </Expression>
@@ -199,7 +196,6 @@
                         <Edge From="2" To="3" Label="Source2" />
                         <Edge From="3" To="4" Label="Source1" />
                         <Edge From="4" To="5" Label="Source1" />
-                        <Edge From="5" To="6" Label="Source1" />
                       </Edges>
                     </Workflow>
                   </Expression>
@@ -221,9 +217,6 @@
                         <Expression xsi:type="Combinator">
                           <Combinator xsi:type="rx:Zip" />
                         </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:DistinctUntilChanged" />
-                        </Expression>
                         <Expression xsi:type="MulticastSubject">
                           <Name>SetIsRightRewardAmount</Name>
                         </Expression>
@@ -235,7 +228,6 @@
                         <Edge From="2" To="3" Label="Source2" />
                         <Edge From="3" To="4" Label="Source1" />
                         <Edge From="4" To="5" Label="Source1" />
-                        <Edge From="5" To="6" Label="Source1" />
                       </Edges>
                     </Workflow>
                   </Expression>

--- a/src/Extensions/TaskEngine.bonsai
+++ b/src/Extensions/TaskEngine.bonsai
@@ -26,78 +26,6 @@
             <Expression xsi:type="MulticastSubject">
               <Name>GlobalTrial</Name>
             </Expression>
-            <Expression xsi:type="GroupWorkflow">
-              <Name>SetLeftRewardSize</Name>
-              <Workflow>
-                <Nodes>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="BooleanProperty">
-                      <Value>false</Value>
-                    </Combinator>
-                  </Expression>
-                  <Expression xsi:type="SubscribeSubject">
-                    <Name>ThisTrial</Name>
-                  </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>RewardSize.Left</Selector>
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="rx:Zip" />
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="rx:DistinctUntilChanged" />
-                  </Expression>
-                  <Expression xsi:type="MulticastSubject">
-                    <Name>SetIsRightRewardAmount</Name>
-                  </Expression>
-                  <Expression xsi:type="WorkflowOutput" />
-                </Nodes>
-                <Edges>
-                  <Edge From="0" To="3" Label="Source1" />
-                  <Edge From="1" To="2" Label="Source1" />
-                  <Edge From="2" To="3" Label="Source2" />
-                  <Edge From="3" To="4" Label="Source1" />
-                  <Edge From="4" To="5" Label="Source1" />
-                  <Edge From="5" To="6" Label="Source1" />
-                </Edges>
-              </Workflow>
-            </Expression>
-            <Expression xsi:type="GroupWorkflow">
-              <Name>SetRightRewardSize</Name>
-              <Workflow>
-                <Nodes>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="BooleanProperty">
-                      <Value>true</Value>
-                    </Combinator>
-                  </Expression>
-                  <Expression xsi:type="SubscribeSubject">
-                    <Name>ThisTrial</Name>
-                  </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>RewardSize.Right</Selector>
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="rx:Zip" />
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="rx:DistinctUntilChanged" />
-                  </Expression>
-                  <Expression xsi:type="MulticastSubject">
-                    <Name>SetIsRightRewardAmount</Name>
-                  </Expression>
-                  <Expression xsi:type="WorkflowOutput" />
-                </Nodes>
-                <Edges>
-                  <Edge From="0" To="3" Label="Source1" />
-                  <Edge From="1" To="2" Label="Source1" />
-                  <Edge From="2" To="3" Label="Source2" />
-                  <Edge From="3" To="4" Label="Source1" />
-                  <Edge From="4" To="5" Label="Source1" />
-                  <Edge From="5" To="6" Label="Source1" />
-                </Edges>
-              </Workflow>
-            </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="py:GetRuntime" />
             </Expression>
@@ -247,6 +175,78 @@
                     <Name>QuiescentPeriod</Name>
                     <Workflow>
                       <Nodes>
+                        <Expression xsi:type="GroupWorkflow">
+                          <Name>SetRightRewardSize</Name>
+                          <Workflow>
+                            <Nodes>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="BooleanProperty">
+                                  <Value>true</Value>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="SubscribeSubject">
+                                <Name>ThisTrial</Name>
+                              </Expression>
+                              <Expression xsi:type="MemberSelector">
+                                <Selector>RewardSize.Right</Selector>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:Zip" />
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:DistinctUntilChanged" />
+                              </Expression>
+                              <Expression xsi:type="MulticastSubject">
+                                <Name>SetIsRightRewardAmount</Name>
+                              </Expression>
+                              <Expression xsi:type="WorkflowOutput" />
+                            </Nodes>
+                            <Edges>
+                              <Edge From="0" To="3" Label="Source1" />
+                              <Edge From="1" To="2" Label="Source1" />
+                              <Edge From="2" To="3" Label="Source2" />
+                              <Edge From="3" To="4" Label="Source1" />
+                              <Edge From="4" To="5" Label="Source1" />
+                              <Edge From="5" To="6" Label="Source1" />
+                            </Edges>
+                          </Workflow>
+                        </Expression>
+                        <Expression xsi:type="GroupWorkflow">
+                          <Name>SetLeftRewardSize</Name>
+                          <Workflow>
+                            <Nodes>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="BooleanProperty">
+                                  <Value>false</Value>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="SubscribeSubject">
+                                <Name>ThisTrial</Name>
+                              </Expression>
+                              <Expression xsi:type="MemberSelector">
+                                <Selector>RewardSize.Left</Selector>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:Zip" />
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:DistinctUntilChanged" />
+                              </Expression>
+                              <Expression xsi:type="MulticastSubject">
+                                <Name>SetIsRightRewardAmount</Name>
+                              </Expression>
+                              <Expression xsi:type="WorkflowOutput" />
+                            </Nodes>
+                            <Edges>
+                              <Edge From="0" To="3" Label="Source1" />
+                              <Edge From="1" To="2" Label="Source1" />
+                              <Edge From="2" To="3" Label="Source2" />
+                              <Edge From="3" To="4" Label="Source1" />
+                              <Edge From="4" To="5" Label="Source1" />
+                              <Edge From="5" To="6" Label="Source1" />
+                            </Edges>
+                          </Workflow>
+                        </Expression>
                         <Expression xsi:type="Unit" />
                         <Expression xsi:type="SubscribeSubject">
                           <Name>IsRightLickEvent</Name>
@@ -432,23 +432,23 @@
                         </Expression>
                       </Nodes>
                       <Edges>
-                        <Edge From="0" To="4" Label="Source1" />
-                        <Edge From="1" To="2" Label="Source1" />
-                        <Edge From="2" To="3" Label="Source1" />
-                        <Edge From="3" To="4" Label="Source2" />
+                        <Edge From="2" To="6" Label="Source1" />
+                        <Edge From="3" To="4" Label="Source1" />
                         <Edge From="4" To="5" Label="Source1" />
-                        <Edge From="5" To="6" Label="Source1" />
+                        <Edge From="5" To="6" Label="Source2" />
                         <Edge From="6" To="7" Label="Source1" />
                         <Edge From="7" To="8" Label="Source1" />
                         <Edge From="8" To="9" Label="Source1" />
+                        <Edge From="9" To="10" Label="Source1" />
                         <Edge From="10" To="11" Label="Source1" />
-                        <Edge From="11" To="12" Label="Source1" />
+                        <Edge From="12" To="13" Label="Source1" />
                         <Edge From="13" To="14" Label="Source1" />
-                        <Edge From="14" To="15" Label="Source1" />
-                        <Edge From="15" To="19" Label="Source1" />
+                        <Edge From="15" To="16" Label="Source1" />
                         <Edge From="16" To="17" Label="Source1" />
-                        <Edge From="17" To="18" Label="Source1" />
-                        <Edge From="18" To="19" Label="Source2" />
+                        <Edge From="17" To="21" Label="Source1" />
+                        <Edge From="18" To="19" Label="Source1" />
+                        <Edge From="19" To="20" Label="Source1" />
+                        <Edge From="20" To="21" Label="Source2" />
                       </Edges>
                     </Workflow>
                   </Expression>
@@ -1237,6 +1237,30 @@
                         <Expression xsi:type="rx:AsyncSubject">
                           <Name>thisTrialOutcome</Name>
                         </Expression>
+                        <Expression xsi:type="SubscribeSubject">
+                          <Name>ThisTrial</Name>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="rx:Take">
+                            <rx:Count>1</rx:Count>
+                          </Combinator>
+                        </Expression>
+                        <Expression xsi:type="MemberSelector">
+                          <Selector>InterTrialIntervalDuration</Selector>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="p3:TimeSpanFromSeconds" />
+                        </Expression>
+                        <Expression xsi:type="PropertyMapping">
+                          <PropertyMappings>
+                            <Property Name="DueTime" />
+                          </PropertyMappings>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="rx:Timer">
+                            <rx:DueTime>PT5S</rx:DueTime>
+                          </Combinator>
+                        </Expression>
                         <Expression xsi:type="GroupWorkflow">
                           <Name>SampleNextTrial</Name>
                           <Workflow>
@@ -1359,108 +1383,6 @@
                               <Edge From="9" To="10" Label="Source1" />
                             </Edges>
                           </Workflow>
-                        </Expression>
-                        <Expression xsi:type="rx:BehaviorSubject">
-                          <Name>NextTrial</Name>
-                        </Expression>
-                        <Expression xsi:type="GroupWorkflow">
-                          <Name>SetLeftRewardSize</Name>
-                          <Workflow>
-                            <Nodes>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="BooleanProperty">
-                                  <Value>false</Value>
-                                </Combinator>
-                              </Expression>
-                              <Expression xsi:type="SubscribeSubject">
-                                <Name>NextTrial</Name>
-                              </Expression>
-                              <Expression xsi:type="MemberSelector">
-                                <Selector>RewardSize.Left</Selector>
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="rx:Zip" />
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="rx:DistinctUntilChanged" />
-                              </Expression>
-                              <Expression xsi:type="MulticastSubject">
-                                <Name>SetIsRightRewardAmount</Name>
-                              </Expression>
-                              <Expression xsi:type="WorkflowOutput" />
-                            </Nodes>
-                            <Edges>
-                              <Edge From="0" To="3" Label="Source1" />
-                              <Edge From="1" To="2" Label="Source1" />
-                              <Edge From="2" To="3" Label="Source2" />
-                              <Edge From="3" To="4" Label="Source1" />
-                              <Edge From="4" To="5" Label="Source1" />
-                              <Edge From="5" To="6" Label="Source1" />
-                            </Edges>
-                          </Workflow>
-                        </Expression>
-                        <Expression xsi:type="GroupWorkflow">
-                          <Name>SetRightRewardSize</Name>
-                          <Workflow>
-                            <Nodes>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="BooleanProperty">
-                                  <Value>true</Value>
-                                </Combinator>
-                              </Expression>
-                              <Expression xsi:type="SubscribeSubject">
-                                <Name>NextTrial</Name>
-                              </Expression>
-                              <Expression xsi:type="MemberSelector">
-                                <Selector>RewardSize.Right</Selector>
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="rx:Zip" />
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="rx:DistinctUntilChanged" />
-                              </Expression>
-                              <Expression xsi:type="MulticastSubject">
-                                <Name>SetIsRightRewardAmount</Name>
-                              </Expression>
-                              <Expression xsi:type="WorkflowOutput" />
-                            </Nodes>
-                            <Edges>
-                              <Edge From="0" To="3" Label="Source1" />
-                              <Edge From="1" To="2" Label="Source1" />
-                              <Edge From="2" To="3" Label="Source2" />
-                              <Edge From="3" To="4" Label="Source1" />
-                              <Edge From="4" To="5" Label="Source1" />
-                              <Edge From="5" To="6" Label="Source1" />
-                            </Edges>
-                          </Workflow>
-                        </Expression>
-                        <Expression xsi:type="SubscribeSubject">
-                          <Name>ThisTrial</Name>
-                        </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:Take">
-                            <rx:Count>1</rx:Count>
-                          </Combinator>
-                        </Expression>
-                        <Expression xsi:type="MemberSelector">
-                          <Selector>InterTrialIntervalDuration</Selector>
-                        </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="p3:TimeSpanFromSeconds" />
-                        </Expression>
-                        <Expression xsi:type="PropertyMapping">
-                          <PropertyMappings>
-                            <Property Name="DueTime" />
-                          </PropertyMappings>
-                        </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:Timer">
-                            <rx:DueTime>PT5S</rx:DueTime>
-                          </Combinator>
-                        </Expression>
-                        <Expression xsi:type="SubscribeSubject">
-                          <Name>NextTrial</Name>
                         </Expression>
                         <Expression xsi:type="SubscribeSubject">
                           <Name>GlobalAutoWaterState</Name>
@@ -1602,30 +1524,29 @@
                         <Edge From="11" To="12" Label="Source1" />
                         <Edge From="12" To="13" Label="Source1" />
                         <Edge From="14" To="15" Label="Source1" />
+                        <Edge From="15" To="16" Label="Source1" />
+                        <Edge From="16" To="17" Label="Source1" />
+                        <Edge From="17" To="18" Label="Source1" />
                         <Edge From="18" To="19" Label="Source1" />
-                        <Edge From="19" To="20" Label="Source1" />
-                        <Edge From="20" To="21" Label="Source1" />
+                        <Edge From="19" To="28" Label="Source1" />
+                        <Edge From="20" To="23" Label="Source1" />
                         <Edge From="21" To="22" Label="Source1" />
-                        <Edge From="22" To="23" Label="Source1" />
-                        <Edge From="23" To="32" Label="Source1" />
-                        <Edge From="24" To="27" Label="Source1" />
+                        <Edge From="22" To="23" Label="Source2" />
+                        <Edge From="23" To="24" Label="Source1" />
+                        <Edge From="24" To="25" Label="Source1" />
                         <Edge From="25" To="26" Label="Source1" />
-                        <Edge From="26" To="27" Label="Source2" />
-                        <Edge From="27" To="28" Label="Source1" />
+                        <Edge From="26" To="28" Label="Source2" />
+                        <Edge From="27" To="28" Label="Source3" />
                         <Edge From="28" To="29" Label="Source1" />
                         <Edge From="29" To="30" Label="Source1" />
-                        <Edge From="30" To="32" Label="Source2" />
-                        <Edge From="31" To="32" Label="Source3" />
+                        <Edge From="30" To="31" Label="Source1" />
                         <Edge From="32" To="33" Label="Source1" />
                         <Edge From="33" To="34" Label="Source1" />
                         <Edge From="34" To="35" Label="Source1" />
+                        <Edge From="35" To="36" Label="Source1" />
                         <Edge From="36" To="37" Label="Source1" />
-                        <Edge From="37" To="38" Label="Source1" />
                         <Edge From="38" To="39" Label="Source1" />
                         <Edge From="39" To="40" Label="Source1" />
-                        <Edge From="40" To="41" Label="Source1" />
-                        <Edge From="42" To="43" Label="Source1" />
-                        <Edge From="43" To="44" Label="Source1" />
                       </Edges>
                     </Workflow>
                   </Expression>
@@ -1673,28 +1594,28 @@
           <Edges>
             <Edge From="1" To="2" Label="Source1" />
             <Edge From="2" To="3" Label="Source1" />
-            <Edge From="6" To="7" Label="Source1" />
+            <Edge From="4" To="5" Label="Source1" />
+            <Edge From="5" To="6" Label="Source1" />
+            <Edge From="6" To="11" Label="Source1" />
             <Edge From="7" To="8" Label="Source1" />
-            <Edge From="8" To="13" Label="Source1" />
+            <Edge From="8" To="9" Label="Source1" />
             <Edge From="9" To="10" Label="Source1" />
-            <Edge From="10" To="11" Label="Source1" />
+            <Edge From="10" To="11" Label="Source2" />
             <Edge From="11" To="12" Label="Source1" />
-            <Edge From="12" To="13" Label="Source2" />
+            <Edge From="12" To="13" Label="Source1" />
             <Edge From="13" To="14" Label="Source1" />
             <Edge From="14" To="15" Label="Source1" />
-            <Edge From="15" To="16" Label="Source1" />
+            <Edge From="15" To="18" Label="Source1" />
             <Edge From="16" To="17" Label="Source1" />
-            <Edge From="17" To="20" Label="Source1" />
+            <Edge From="17" To="18" Label="Source2" />
             <Edge From="18" To="19" Label="Source1" />
-            <Edge From="19" To="20" Label="Source2" />
+            <Edge From="19" To="20" Label="Source1" />
             <Edge From="20" To="21" Label="Source1" />
-            <Edge From="21" To="22" Label="Source1" />
             <Edge From="22" To="23" Label="Source1" />
+            <Edge From="23" To="24" Label="Source1" />
             <Edge From="24" To="25" Label="Source1" />
             <Edge From="25" To="26" Label="Source1" />
             <Edge From="26" To="27" Label="Source1" />
-            <Edge From="27" To="28" Label="Source1" />
-            <Edge From="28" To="29" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>

--- a/src/Extensions/TaskEngine.bonsai
+++ b/src/Extensions/TaskEngine.bonsai
@@ -26,6 +26,78 @@
             <Expression xsi:type="MulticastSubject">
               <Name>GlobalTrial</Name>
             </Expression>
+            <Expression xsi:type="GroupWorkflow">
+              <Name>SetLeftRewardSize</Name>
+              <Workflow>
+                <Nodes>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="BooleanProperty">
+                      <Value>false</Value>
+                    </Combinator>
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>ThisTrial</Name>
+                  </Expression>
+                  <Expression xsi:type="MemberSelector">
+                    <Selector>RewardSize.Left</Selector>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:Zip" />
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:DistinctUntilChanged" />
+                  </Expression>
+                  <Expression xsi:type="MulticastSubject">
+                    <Name>SetIsRightRewardAmount</Name>
+                  </Expression>
+                  <Expression xsi:type="WorkflowOutput" />
+                </Nodes>
+                <Edges>
+                  <Edge From="0" To="3" Label="Source1" />
+                  <Edge From="1" To="2" Label="Source1" />
+                  <Edge From="2" To="3" Label="Source2" />
+                  <Edge From="3" To="4" Label="Source1" />
+                  <Edge From="4" To="5" Label="Source1" />
+                  <Edge From="5" To="6" Label="Source1" />
+                </Edges>
+              </Workflow>
+            </Expression>
+            <Expression xsi:type="GroupWorkflow">
+              <Name>SetRightRewardSize</Name>
+              <Workflow>
+                <Nodes>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="BooleanProperty">
+                      <Value>true</Value>
+                    </Combinator>
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>ThisTrial</Name>
+                  </Expression>
+                  <Expression xsi:type="MemberSelector">
+                    <Selector>RewardSize.Right</Selector>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:Zip" />
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:DistinctUntilChanged" />
+                  </Expression>
+                  <Expression xsi:type="MulticastSubject">
+                    <Name>SetIsRightRewardAmount</Name>
+                  </Expression>
+                  <Expression xsi:type="WorkflowOutput" />
+                </Nodes>
+                <Edges>
+                  <Edge From="0" To="3" Label="Source1" />
+                  <Edge From="1" To="2" Label="Source1" />
+                  <Edge From="2" To="3" Label="Source2" />
+                  <Edge From="3" To="4" Label="Source1" />
+                  <Edge From="4" To="5" Label="Source1" />
+                  <Edge From="5" To="6" Label="Source1" />
+                </Edges>
+              </Workflow>
+            </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="py:GetRuntime" />
             </Expression>
@@ -175,78 +247,6 @@
                     <Name>QuiescentPeriod</Name>
                     <Workflow>
                       <Nodes>
-                        <Expression xsi:type="GroupWorkflow">
-                          <Name>SetRightRewardSize</Name>
-                          <Workflow>
-                            <Nodes>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="BooleanProperty">
-                                  <Value>true</Value>
-                                </Combinator>
-                              </Expression>
-                              <Expression xsi:type="SubscribeSubject">
-                                <Name>ThisTrial</Name>
-                              </Expression>
-                              <Expression xsi:type="MemberSelector">
-                                <Selector>RewardSize.Right</Selector>
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="rx:Zip" />
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="rx:DistinctUntilChanged" />
-                              </Expression>
-                              <Expression xsi:type="MulticastSubject">
-                                <Name>SetIsRightRewardAmount</Name>
-                              </Expression>
-                              <Expression xsi:type="WorkflowOutput" />
-                            </Nodes>
-                            <Edges>
-                              <Edge From="0" To="3" Label="Source1" />
-                              <Edge From="1" To="2" Label="Source1" />
-                              <Edge From="2" To="3" Label="Source2" />
-                              <Edge From="3" To="4" Label="Source1" />
-                              <Edge From="4" To="5" Label="Source1" />
-                              <Edge From="5" To="6" Label="Source1" />
-                            </Edges>
-                          </Workflow>
-                        </Expression>
-                        <Expression xsi:type="GroupWorkflow">
-                          <Name>SetLeftRewardSize</Name>
-                          <Workflow>
-                            <Nodes>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="BooleanProperty">
-                                  <Value>false</Value>
-                                </Combinator>
-                              </Expression>
-                              <Expression xsi:type="SubscribeSubject">
-                                <Name>ThisTrial</Name>
-                              </Expression>
-                              <Expression xsi:type="MemberSelector">
-                                <Selector>RewardSize.Left</Selector>
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="rx:Zip" />
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="rx:DistinctUntilChanged" />
-                              </Expression>
-                              <Expression xsi:type="MulticastSubject">
-                                <Name>SetIsRightRewardAmount</Name>
-                              </Expression>
-                              <Expression xsi:type="WorkflowOutput" />
-                            </Nodes>
-                            <Edges>
-                              <Edge From="0" To="3" Label="Source1" />
-                              <Edge From="1" To="2" Label="Source1" />
-                              <Edge From="2" To="3" Label="Source2" />
-                              <Edge From="3" To="4" Label="Source1" />
-                              <Edge From="4" To="5" Label="Source1" />
-                              <Edge From="5" To="6" Label="Source1" />
-                            </Edges>
-                          </Workflow>
-                        </Expression>
                         <Expression xsi:type="Unit" />
                         <Expression xsi:type="SubscribeSubject">
                           <Name>IsRightLickEvent</Name>
@@ -432,23 +432,23 @@
                         </Expression>
                       </Nodes>
                       <Edges>
-                        <Edge From="2" To="6" Label="Source1" />
-                        <Edge From="3" To="4" Label="Source1" />
+                        <Edge From="0" To="4" Label="Source1" />
+                        <Edge From="1" To="2" Label="Source1" />
+                        <Edge From="2" To="3" Label="Source1" />
+                        <Edge From="3" To="4" Label="Source2" />
                         <Edge From="4" To="5" Label="Source1" />
-                        <Edge From="5" To="6" Label="Source2" />
+                        <Edge From="5" To="6" Label="Source1" />
                         <Edge From="6" To="7" Label="Source1" />
                         <Edge From="7" To="8" Label="Source1" />
                         <Edge From="8" To="9" Label="Source1" />
-                        <Edge From="9" To="10" Label="Source1" />
                         <Edge From="10" To="11" Label="Source1" />
-                        <Edge From="12" To="13" Label="Source1" />
+                        <Edge From="11" To="12" Label="Source1" />
                         <Edge From="13" To="14" Label="Source1" />
-                        <Edge From="15" To="16" Label="Source1" />
+                        <Edge From="14" To="15" Label="Source1" />
+                        <Edge From="15" To="19" Label="Source1" />
                         <Edge From="16" To="17" Label="Source1" />
-                        <Edge From="17" To="21" Label="Source1" />
-                        <Edge From="18" To="19" Label="Source1" />
-                        <Edge From="19" To="20" Label="Source1" />
-                        <Edge From="20" To="21" Label="Source2" />
+                        <Edge From="17" To="18" Label="Source1" />
+                        <Edge From="18" To="19" Label="Source2" />
                       </Edges>
                     </Workflow>
                   </Expression>
@@ -1237,30 +1237,6 @@
                         <Expression xsi:type="rx:AsyncSubject">
                           <Name>thisTrialOutcome</Name>
                         </Expression>
-                        <Expression xsi:type="SubscribeSubject">
-                          <Name>ThisTrial</Name>
-                        </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:Take">
-                            <rx:Count>1</rx:Count>
-                          </Combinator>
-                        </Expression>
-                        <Expression xsi:type="MemberSelector">
-                          <Selector>InterTrialIntervalDuration</Selector>
-                        </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="p3:TimeSpanFromSeconds" />
-                        </Expression>
-                        <Expression xsi:type="PropertyMapping">
-                          <PropertyMappings>
-                            <Property Name="DueTime" />
-                          </PropertyMappings>
-                        </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:Timer">
-                            <rx:DueTime>PT5S</rx:DueTime>
-                          </Combinator>
-                        </Expression>
                         <Expression xsi:type="GroupWorkflow">
                           <Name>SampleNextTrial</Name>
                           <Workflow>
@@ -1383,6 +1359,108 @@
                               <Edge From="9" To="10" Label="Source1" />
                             </Edges>
                           </Workflow>
+                        </Expression>
+                        <Expression xsi:type="rx:BehaviorSubject">
+                          <Name>NextTrial</Name>
+                        </Expression>
+                        <Expression xsi:type="GroupWorkflow">
+                          <Name>SetLeftRewardSize</Name>
+                          <Workflow>
+                            <Nodes>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="BooleanProperty">
+                                  <Value>false</Value>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="SubscribeSubject">
+                                <Name>NextTrial</Name>
+                              </Expression>
+                              <Expression xsi:type="MemberSelector">
+                                <Selector>RewardSize.Left</Selector>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:Zip" />
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:DistinctUntilChanged" />
+                              </Expression>
+                              <Expression xsi:type="MulticastSubject">
+                                <Name>SetIsRightRewardAmount</Name>
+                              </Expression>
+                              <Expression xsi:type="WorkflowOutput" />
+                            </Nodes>
+                            <Edges>
+                              <Edge From="0" To="3" Label="Source1" />
+                              <Edge From="1" To="2" Label="Source1" />
+                              <Edge From="2" To="3" Label="Source2" />
+                              <Edge From="3" To="4" Label="Source1" />
+                              <Edge From="4" To="5" Label="Source1" />
+                              <Edge From="5" To="6" Label="Source1" />
+                            </Edges>
+                          </Workflow>
+                        </Expression>
+                        <Expression xsi:type="GroupWorkflow">
+                          <Name>SetRightRewardSize</Name>
+                          <Workflow>
+                            <Nodes>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="BooleanProperty">
+                                  <Value>true</Value>
+                                </Combinator>
+                              </Expression>
+                              <Expression xsi:type="SubscribeSubject">
+                                <Name>NextTrial</Name>
+                              </Expression>
+                              <Expression xsi:type="MemberSelector">
+                                <Selector>RewardSize.Right</Selector>
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:Zip" />
+                              </Expression>
+                              <Expression xsi:type="Combinator">
+                                <Combinator xsi:type="rx:DistinctUntilChanged" />
+                              </Expression>
+                              <Expression xsi:type="MulticastSubject">
+                                <Name>SetIsRightRewardAmount</Name>
+                              </Expression>
+                              <Expression xsi:type="WorkflowOutput" />
+                            </Nodes>
+                            <Edges>
+                              <Edge From="0" To="3" Label="Source1" />
+                              <Edge From="1" To="2" Label="Source1" />
+                              <Edge From="2" To="3" Label="Source2" />
+                              <Edge From="3" To="4" Label="Source1" />
+                              <Edge From="4" To="5" Label="Source1" />
+                              <Edge From="5" To="6" Label="Source1" />
+                            </Edges>
+                          </Workflow>
+                        </Expression>
+                        <Expression xsi:type="SubscribeSubject">
+                          <Name>ThisTrial</Name>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="rx:Take">
+                            <rx:Count>1</rx:Count>
+                          </Combinator>
+                        </Expression>
+                        <Expression xsi:type="MemberSelector">
+                          <Selector>InterTrialIntervalDuration</Selector>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="p3:TimeSpanFromSeconds" />
+                        </Expression>
+                        <Expression xsi:type="PropertyMapping">
+                          <PropertyMappings>
+                            <Property Name="DueTime" />
+                          </PropertyMappings>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="rx:Timer">
+                            <rx:DueTime>PT5S</rx:DueTime>
+                          </Combinator>
+                        </Expression>
+                        <Expression xsi:type="SubscribeSubject">
+                          <Name>NextTrial</Name>
                         </Expression>
                         <Expression xsi:type="SubscribeSubject">
                           <Name>GlobalAutoWaterState</Name>
@@ -1524,29 +1602,30 @@
                         <Edge From="11" To="12" Label="Source1" />
                         <Edge From="12" To="13" Label="Source1" />
                         <Edge From="14" To="15" Label="Source1" />
-                        <Edge From="15" To="16" Label="Source1" />
-                        <Edge From="16" To="17" Label="Source1" />
-                        <Edge From="17" To="18" Label="Source1" />
                         <Edge From="18" To="19" Label="Source1" />
-                        <Edge From="19" To="28" Label="Source1" />
-                        <Edge From="20" To="23" Label="Source1" />
+                        <Edge From="19" To="20" Label="Source1" />
+                        <Edge From="20" To="21" Label="Source1" />
                         <Edge From="21" To="22" Label="Source1" />
-                        <Edge From="22" To="23" Label="Source2" />
-                        <Edge From="23" To="24" Label="Source1" />
-                        <Edge From="24" To="25" Label="Source1" />
+                        <Edge From="22" To="23" Label="Source1" />
+                        <Edge From="23" To="32" Label="Source1" />
+                        <Edge From="24" To="27" Label="Source1" />
                         <Edge From="25" To="26" Label="Source1" />
-                        <Edge From="26" To="28" Label="Source2" />
-                        <Edge From="27" To="28" Label="Source3" />
+                        <Edge From="26" To="27" Label="Source2" />
+                        <Edge From="27" To="28" Label="Source1" />
                         <Edge From="28" To="29" Label="Source1" />
                         <Edge From="29" To="30" Label="Source1" />
-                        <Edge From="30" To="31" Label="Source1" />
+                        <Edge From="30" To="32" Label="Source2" />
+                        <Edge From="31" To="32" Label="Source3" />
                         <Edge From="32" To="33" Label="Source1" />
                         <Edge From="33" To="34" Label="Source1" />
                         <Edge From="34" To="35" Label="Source1" />
-                        <Edge From="35" To="36" Label="Source1" />
                         <Edge From="36" To="37" Label="Source1" />
+                        <Edge From="37" To="38" Label="Source1" />
                         <Edge From="38" To="39" Label="Source1" />
                         <Edge From="39" To="40" Label="Source1" />
+                        <Edge From="40" To="41" Label="Source1" />
+                        <Edge From="42" To="43" Label="Source1" />
+                        <Edge From="43" To="44" Label="Source1" />
                       </Edges>
                     </Workflow>
                   </Expression>
@@ -1594,28 +1673,28 @@
           <Edges>
             <Edge From="1" To="2" Label="Source1" />
             <Edge From="2" To="3" Label="Source1" />
-            <Edge From="4" To="5" Label="Source1" />
-            <Edge From="5" To="6" Label="Source1" />
-            <Edge From="6" To="11" Label="Source1" />
+            <Edge From="6" To="7" Label="Source1" />
             <Edge From="7" To="8" Label="Source1" />
-            <Edge From="8" To="9" Label="Source1" />
+            <Edge From="8" To="13" Label="Source1" />
             <Edge From="9" To="10" Label="Source1" />
-            <Edge From="10" To="11" Label="Source2" />
+            <Edge From="10" To="11" Label="Source1" />
             <Edge From="11" To="12" Label="Source1" />
-            <Edge From="12" To="13" Label="Source1" />
+            <Edge From="12" To="13" Label="Source2" />
             <Edge From="13" To="14" Label="Source1" />
             <Edge From="14" To="15" Label="Source1" />
-            <Edge From="15" To="18" Label="Source1" />
+            <Edge From="15" To="16" Label="Source1" />
             <Edge From="16" To="17" Label="Source1" />
-            <Edge From="17" To="18" Label="Source2" />
+            <Edge From="17" To="20" Label="Source1" />
             <Edge From="18" To="19" Label="Source1" />
-            <Edge From="19" To="20" Label="Source1" />
+            <Edge From="19" To="20" Label="Source2" />
             <Edge From="20" To="21" Label="Source1" />
+            <Edge From="21" To="22" Label="Source1" />
             <Edge From="22" To="23" Label="Source1" />
-            <Edge From="23" To="24" Label="Source1" />
             <Edge From="24" To="25" Label="Source1" />
             <Edge From="25" To="26" Label="Source1" />
             <Edge From="26" To="27" Label="Source1" />
+            <Edge From="27" To="28" Label="Source1" />
+            <Edge From="28" To="29" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>

--- a/src/Extensions/TaskEngine.bonsai
+++ b/src/Extensions/TaskEngine.bonsai
@@ -26,78 +26,6 @@
             <Expression xsi:type="MulticastSubject">
               <Name>GlobalTrial</Name>
             </Expression>
-            <Expression xsi:type="GroupWorkflow">
-              <Name>SetLeftRewardSize</Name>
-              <Workflow>
-                <Nodes>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="BooleanProperty">
-                      <Value>false</Value>
-                    </Combinator>
-                  </Expression>
-                  <Expression xsi:type="SubscribeSubject">
-                    <Name>ThisTrial</Name>
-                  </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>RewardSize.Left</Selector>
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="rx:Zip" />
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="rx:DistinctUntilChanged" />
-                  </Expression>
-                  <Expression xsi:type="MulticastSubject">
-                    <Name>SetIsRightRewardAmount</Name>
-                  </Expression>
-                  <Expression xsi:type="WorkflowOutput" />
-                </Nodes>
-                <Edges>
-                  <Edge From="0" To="3" Label="Source1" />
-                  <Edge From="1" To="2" Label="Source1" />
-                  <Edge From="2" To="3" Label="Source2" />
-                  <Edge From="3" To="4" Label="Source1" />
-                  <Edge From="4" To="5" Label="Source1" />
-                  <Edge From="5" To="6" Label="Source1" />
-                </Edges>
-              </Workflow>
-            </Expression>
-            <Expression xsi:type="GroupWorkflow">
-              <Name>SetRightRewardSize</Name>
-              <Workflow>
-                <Nodes>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="BooleanProperty">
-                      <Value>true</Value>
-                    </Combinator>
-                  </Expression>
-                  <Expression xsi:type="SubscribeSubject">
-                    <Name>ThisTrial</Name>
-                  </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>RewardSize.Right</Selector>
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="rx:Zip" />
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="rx:DistinctUntilChanged" />
-                  </Expression>
-                  <Expression xsi:type="MulticastSubject">
-                    <Name>SetIsRightRewardAmount</Name>
-                  </Expression>
-                  <Expression xsi:type="WorkflowOutput" />
-                </Nodes>
-                <Edges>
-                  <Edge From="0" To="3" Label="Source1" />
-                  <Edge From="1" To="2" Label="Source1" />
-                  <Edge From="2" To="3" Label="Source2" />
-                  <Edge From="3" To="4" Label="Source1" />
-                  <Edge From="4" To="5" Label="Source1" />
-                  <Edge From="5" To="6" Label="Source1" />
-                </Edges>
-              </Workflow>
-            </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="py:GetRuntime" />
             </Expression>
@@ -233,6 +161,99 @@
               <Combinator xsi:type="rx:Take">
                 <rx:Count>1</rx:Count>
               </Combinator>
+            </Expression>
+            <Expression xsi:type="rx:SelectMany">
+              <Name>PreTrial</Name>
+              <Description>Configure necessary parameters before trial is run </Description>
+              <Workflow>
+                <Nodes>
+                  <Expression xsi:type="GroupWorkflow">
+                    <Name>SetRightRewardSize</Name>
+                    <Workflow>
+                      <Nodes>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="BooleanProperty">
+                            <Value>true</Value>
+                          </Combinator>
+                        </Expression>
+                        <Expression xsi:type="SubscribeSubject">
+                          <Name>ThisTrial</Name>
+                        </Expression>
+                        <Expression xsi:type="MemberSelector">
+                          <Selector>RewardSize.Right</Selector>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="rx:Zip" />
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="rx:DistinctUntilChanged" />
+                        </Expression>
+                        <Expression xsi:type="MulticastSubject">
+                          <Name>SetIsRightRewardAmount</Name>
+                        </Expression>
+                        <Expression xsi:type="WorkflowOutput" />
+                      </Nodes>
+                      <Edges>
+                        <Edge From="0" To="3" Label="Source1" />
+                        <Edge From="1" To="2" Label="Source1" />
+                        <Edge From="2" To="3" Label="Source2" />
+                        <Edge From="3" To="4" Label="Source1" />
+                        <Edge From="4" To="5" Label="Source1" />
+                        <Edge From="5" To="6" Label="Source1" />
+                      </Edges>
+                    </Workflow>
+                  </Expression>
+                  <Expression xsi:type="GroupWorkflow">
+                    <Name>SetLeftRewardSize</Name>
+                    <Workflow>
+                      <Nodes>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="BooleanProperty">
+                            <Value>false</Value>
+                          </Combinator>
+                        </Expression>
+                        <Expression xsi:type="SubscribeSubject">
+                          <Name>ThisTrial</Name>
+                        </Expression>
+                        <Expression xsi:type="MemberSelector">
+                          <Selector>RewardSize.Left</Selector>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="rx:Zip" />
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="rx:DistinctUntilChanged" />
+                        </Expression>
+                        <Expression xsi:type="MulticastSubject">
+                          <Name>SetIsRightRewardAmount</Name>
+                        </Expression>
+                        <Expression xsi:type="WorkflowOutput" />
+                      </Nodes>
+                      <Edges>
+                        <Edge From="0" To="3" Label="Source1" />
+                        <Edge From="1" To="2" Label="Source1" />
+                        <Edge From="2" To="3" Label="Source2" />
+                        <Edge From="3" To="4" Label="Source1" />
+                        <Edge From="4" To="5" Label="Source1" />
+                        <Edge From="5" To="6" Label="Source1" />
+                      </Edges>
+                    </Workflow>
+                  </Expression>
+                  <Expression xsi:type="WorkflowInput">
+                    <Name>Source1</Name>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:Take">
+                      <rx:Count>1</rx:Count>
+                    </Combinator>
+                  </Expression>
+                  <Expression xsi:type="WorkflowOutput" />
+                </Nodes>
+                <Edges>
+                  <Edge From="2" To="3" Label="Source1" />
+                  <Edge From="3" To="4" Label="Source1" />
+                </Edges>
+              </Workflow>
             </Expression>
             <Expression xsi:type="rx:SelectMany">
               <Name>RunTrial</Name>
@@ -1237,6 +1258,30 @@
                         <Expression xsi:type="rx:AsyncSubject">
                           <Name>thisTrialOutcome</Name>
                         </Expression>
+                        <Expression xsi:type="SubscribeSubject">
+                          <Name>ThisTrial</Name>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="rx:Take">
+                            <rx:Count>1</rx:Count>
+                          </Combinator>
+                        </Expression>
+                        <Expression xsi:type="MemberSelector">
+                          <Selector>InterTrialIntervalDuration</Selector>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="p3:TimeSpanFromSeconds" />
+                        </Expression>
+                        <Expression xsi:type="PropertyMapping">
+                          <PropertyMappings>
+                            <Property Name="DueTime" />
+                          </PropertyMappings>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="rx:Timer">
+                            <rx:DueTime>PT5S</rx:DueTime>
+                          </Combinator>
+                        </Expression>
                         <Expression xsi:type="GroupWorkflow">
                           <Name>SampleNextTrial</Name>
                           <Workflow>
@@ -1359,108 +1404,6 @@
                               <Edge From="9" To="10" Label="Source1" />
                             </Edges>
                           </Workflow>
-                        </Expression>
-                        <Expression xsi:type="rx:BehaviorSubject">
-                          <Name>NextTrial</Name>
-                        </Expression>
-                        <Expression xsi:type="GroupWorkflow">
-                          <Name>SetLeftRewardSize</Name>
-                          <Workflow>
-                            <Nodes>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="BooleanProperty">
-                                  <Value>false</Value>
-                                </Combinator>
-                              </Expression>
-                              <Expression xsi:type="SubscribeSubject">
-                                <Name>NextTrial</Name>
-                              </Expression>
-                              <Expression xsi:type="MemberSelector">
-                                <Selector>RewardSize.Left</Selector>
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="rx:Zip" />
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="rx:DistinctUntilChanged" />
-                              </Expression>
-                              <Expression xsi:type="MulticastSubject">
-                                <Name>SetIsRightRewardAmount</Name>
-                              </Expression>
-                              <Expression xsi:type="WorkflowOutput" />
-                            </Nodes>
-                            <Edges>
-                              <Edge From="0" To="3" Label="Source1" />
-                              <Edge From="1" To="2" Label="Source1" />
-                              <Edge From="2" To="3" Label="Source2" />
-                              <Edge From="3" To="4" Label="Source1" />
-                              <Edge From="4" To="5" Label="Source1" />
-                              <Edge From="5" To="6" Label="Source1" />
-                            </Edges>
-                          </Workflow>
-                        </Expression>
-                        <Expression xsi:type="GroupWorkflow">
-                          <Name>SetRightRewardSize</Name>
-                          <Workflow>
-                            <Nodes>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="BooleanProperty">
-                                  <Value>true</Value>
-                                </Combinator>
-                              </Expression>
-                              <Expression xsi:type="SubscribeSubject">
-                                <Name>NextTrial</Name>
-                              </Expression>
-                              <Expression xsi:type="MemberSelector">
-                                <Selector>RewardSize.Right</Selector>
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="rx:Zip" />
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="rx:DistinctUntilChanged" />
-                              </Expression>
-                              <Expression xsi:type="MulticastSubject">
-                                <Name>SetIsRightRewardAmount</Name>
-                              </Expression>
-                              <Expression xsi:type="WorkflowOutput" />
-                            </Nodes>
-                            <Edges>
-                              <Edge From="0" To="3" Label="Source1" />
-                              <Edge From="1" To="2" Label="Source1" />
-                              <Edge From="2" To="3" Label="Source2" />
-                              <Edge From="3" To="4" Label="Source1" />
-                              <Edge From="4" To="5" Label="Source1" />
-                              <Edge From="5" To="6" Label="Source1" />
-                            </Edges>
-                          </Workflow>
-                        </Expression>
-                        <Expression xsi:type="SubscribeSubject">
-                          <Name>ThisTrial</Name>
-                        </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:Take">
-                            <rx:Count>1</rx:Count>
-                          </Combinator>
-                        </Expression>
-                        <Expression xsi:type="MemberSelector">
-                          <Selector>InterTrialIntervalDuration</Selector>
-                        </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="p3:TimeSpanFromSeconds" />
-                        </Expression>
-                        <Expression xsi:type="PropertyMapping">
-                          <PropertyMappings>
-                            <Property Name="DueTime" />
-                          </PropertyMappings>
-                        </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:Timer">
-                            <rx:DueTime>PT5S</rx:DueTime>
-                          </Combinator>
-                        </Expression>
-                        <Expression xsi:type="SubscribeSubject">
-                          <Name>NextTrial</Name>
                         </Expression>
                         <Expression xsi:type="SubscribeSubject">
                           <Name>GlobalAutoWaterState</Name>
@@ -1602,30 +1545,29 @@
                         <Edge From="11" To="12" Label="Source1" />
                         <Edge From="12" To="13" Label="Source1" />
                         <Edge From="14" To="15" Label="Source1" />
+                        <Edge From="15" To="16" Label="Source1" />
+                        <Edge From="16" To="17" Label="Source1" />
+                        <Edge From="17" To="18" Label="Source1" />
                         <Edge From="18" To="19" Label="Source1" />
-                        <Edge From="19" To="20" Label="Source1" />
-                        <Edge From="20" To="21" Label="Source1" />
+                        <Edge From="19" To="28" Label="Source1" />
+                        <Edge From="20" To="23" Label="Source1" />
                         <Edge From="21" To="22" Label="Source1" />
-                        <Edge From="22" To="23" Label="Source1" />
-                        <Edge From="23" To="32" Label="Source1" />
-                        <Edge From="24" To="27" Label="Source1" />
+                        <Edge From="22" To="23" Label="Source2" />
+                        <Edge From="23" To="24" Label="Source1" />
+                        <Edge From="24" To="25" Label="Source1" />
                         <Edge From="25" To="26" Label="Source1" />
-                        <Edge From="26" To="27" Label="Source2" />
-                        <Edge From="27" To="28" Label="Source1" />
+                        <Edge From="26" To="28" Label="Source2" />
+                        <Edge From="27" To="28" Label="Source3" />
                         <Edge From="28" To="29" Label="Source1" />
                         <Edge From="29" To="30" Label="Source1" />
-                        <Edge From="30" To="32" Label="Source2" />
-                        <Edge From="31" To="32" Label="Source3" />
+                        <Edge From="30" To="31" Label="Source1" />
                         <Edge From="32" To="33" Label="Source1" />
                         <Edge From="33" To="34" Label="Source1" />
                         <Edge From="34" To="35" Label="Source1" />
+                        <Edge From="35" To="36" Label="Source1" />
                         <Edge From="36" To="37" Label="Source1" />
-                        <Edge From="37" To="38" Label="Source1" />
                         <Edge From="38" To="39" Label="Source1" />
                         <Edge From="39" To="40" Label="Source1" />
-                        <Edge From="40" To="41" Label="Source1" />
-                        <Edge From="42" To="43" Label="Source1" />
-                        <Edge From="43" To="44" Label="Source1" />
                       </Edges>
                     </Workflow>
                   </Expression>
@@ -1673,28 +1615,29 @@
           <Edges>
             <Edge From="1" To="2" Label="Source1" />
             <Edge From="2" To="3" Label="Source1" />
-            <Edge From="6" To="7" Label="Source1" />
+            <Edge From="4" To="5" Label="Source1" />
+            <Edge From="5" To="6" Label="Source1" />
+            <Edge From="6" To="11" Label="Source1" />
             <Edge From="7" To="8" Label="Source1" />
-            <Edge From="8" To="13" Label="Source1" />
+            <Edge From="8" To="9" Label="Source1" />
             <Edge From="9" To="10" Label="Source1" />
-            <Edge From="10" To="11" Label="Source1" />
+            <Edge From="10" To="11" Label="Source2" />
             <Edge From="11" To="12" Label="Source1" />
-            <Edge From="12" To="13" Label="Source2" />
+            <Edge From="12" To="13" Label="Source1" />
             <Edge From="13" To="14" Label="Source1" />
             <Edge From="14" To="15" Label="Source1" />
-            <Edge From="15" To="16" Label="Source1" />
+            <Edge From="15" To="18" Label="Source1" />
             <Edge From="16" To="17" Label="Source1" />
-            <Edge From="17" To="20" Label="Source1" />
+            <Edge From="17" To="18" Label="Source2" />
             <Edge From="18" To="19" Label="Source1" />
-            <Edge From="19" To="20" Label="Source2" />
+            <Edge From="19" To="20" Label="Source1" />
             <Edge From="20" To="21" Label="Source1" />
-            <Edge From="21" To="22" Label="Source1" />
             <Edge From="22" To="23" Label="Source1" />
+            <Edge From="23" To="24" Label="Source1" />
             <Edge From="24" To="25" Label="Source1" />
             <Edge From="25" To="26" Label="Source1" />
             <Edge From="26" To="27" Label="Source1" />
             <Edge From="27" To="28" Label="Source1" />
-            <Edge From="28" To="29" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>

--- a/src/Extensions/ValveUi.bonsai
+++ b/src/Extensions/ValveUi.bonsai
@@ -366,7 +366,7 @@
                           <Name>DefaultRewardSize</Name>
                         </Expression>
                         <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:Zip" />
+                          <Combinator xsi:type="rx:WithLatestFrom" />
                         </Expression>
                         <Expression xsi:type="MulticastSubject">
                           <Name>SetIsRightRewardAmount</Name>

--- a/src/Extensions/ValveUi.bonsai
+++ b/src/Extensions/ValveUi.bonsai
@@ -363,17 +363,7 @@
                           <Name>Source1</Name>
                         </Expression>
                         <Expression xsi:type="SubscribeSubject">
-                          <Name>TaskLogicParameters</Name>
-                        </Expression>
-                        <Expression xsi:type="MemberSelector">
-                          <Selector>RewardSize</Selector>
-                        </Expression>
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="rx:WithLatestFrom" />
-                        </Expression>
-                        <Expression xsi:type="scr:ExpressionTransform">
-                          <scr:Name>ValveVolume</scr:Name>
-                          <scr:Expression>it.Item1 ? it.Item2.RightValueVolume : it.Item2.LeftValueVolume</scr:Expression>
+                          <Name>DefaultRewardSize</Name>
                         </Expression>
                         <Expression xsi:type="Combinator">
                           <Combinator xsi:type="rx:Zip" />
@@ -384,14 +374,10 @@
                         <Expression xsi:type="WorkflowOutput" />
                       </Nodes>
                       <Edges>
-                        <Edge From="0" To="3" Label="Source1" />
-                        <Edge From="0" To="5" Label="Source1" />
-                        <Edge From="1" To="2" Label="Source1" />
-                        <Edge From="2" To="3" Label="Source2" />
+                        <Edge From="0" To="2" Label="Source1" />
+                        <Edge From="1" To="2" Label="Source2" />
+                        <Edge From="2" To="3" Label="Source1" />
                         <Edge From="3" To="4" Label="Source1" />
-                        <Edge From="4" To="5" Label="Source2" />
-                        <Edge From="5" To="6" Label="Source1" />
-                        <Edge From="6" To="7" Label="Source1" />
                       </Edges>
                     </Workflow>
                   </Expression>
@@ -896,13 +882,7 @@
                           </Combinator>
                         </Expression>
                         <Expression xsi:type="SubscribeSubject">
-                          <Name>TaskLogicParameters</Name>
-                        </Expression>
-                        <Expression xsi:type="MemberSelector">
-                          <Selector>RewardSize</Selector>
-                        </Expression>
-                        <Expression xsi:type="MemberSelector">
-                          <Selector>LeftValueVolume</Selector>
+                          <Name>DefaultRewardSize</Name>
                         </Expression>
                         <Expression xsi:type="Combinator">
                           <Combinator xsi:type="rx:WithLatestFrom" />
@@ -914,12 +894,10 @@
                       </Nodes>
                       <Edges>
                         <Edge From="0" To="1" Label="Source1" />
-                        <Edge From="1" To="5" Label="Source1" />
-                        <Edge From="2" To="3" Label="Source1" />
+                        <Edge From="1" To="3" Label="Source1" />
+                        <Edge From="2" To="3" Label="Source2" />
                         <Edge From="3" To="4" Label="Source1" />
-                        <Edge From="4" To="5" Label="Source2" />
-                        <Edge From="5" To="6" Label="Source1" />
-                        <Edge From="6" To="7" Label="Source1" />
+                        <Edge From="4" To="5" Label="Source1" />
                       </Edges>
                     </Workflow>
                   </Expression>
@@ -1111,13 +1089,7 @@
                           </Combinator>
                         </Expression>
                         <Expression xsi:type="SubscribeSubject">
-                          <Name>TaskLogicParameters</Name>
-                        </Expression>
-                        <Expression xsi:type="MemberSelector">
-                          <Selector>RewardSize</Selector>
-                        </Expression>
-                        <Expression xsi:type="MemberSelector">
-                          <Selector>RightValueVolume</Selector>
+                          <Name>DefaultRewardSize</Name>
                         </Expression>
                         <Expression xsi:type="Combinator">
                           <Combinator xsi:type="rx:WithLatestFrom" />
@@ -1129,12 +1101,10 @@
                       </Nodes>
                       <Edges>
                         <Edge From="0" To="1" Label="Source1" />
-                        <Edge From="1" To="5" Label="Source1" />
-                        <Edge From="2" To="3" Label="Source1" />
+                        <Edge From="1" To="3" Label="Source1" />
+                        <Edge From="2" To="3" Label="Source2" />
                         <Edge From="3" To="4" Label="Source1" />
-                        <Edge From="4" To="5" Label="Source2" />
-                        <Edge From="5" To="6" Label="Source1" />
-                        <Edge From="6" To="7" Label="Source1" />
+                        <Edge From="4" To="5" Label="Source1" />
                       </Edges>
                     </Workflow>
                   </Expression>

--- a/src/aind_behavior_dynamic_foraging/task_logic/__init__.py
+++ b/src/aind_behavior_dynamic_foraging/task_logic/__init__.py
@@ -1,7 +1,7 @@
 from typing import Literal
 
 from aind_behavior_services.task import Task, TaskParameters
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from aind_behavior_dynamic_foraging import (
     __semver__,
@@ -9,12 +9,6 @@ from aind_behavior_dynamic_foraging import (
 
 from . import trial_models as trial_models
 from .trial_generators import IntegrationTestTrialGeneratorSpec, TrialGeneratorSpec
-
-
-class RewardSize(BaseModel):
-    right_value_volume: float = Field(title="Right reward size (uL)")
-    left_value_volume: float = Field(title="Left reward size (uL)")
-
 
 # ==================== MAIN TASK LOGIC CLASSES ====================
 
@@ -28,9 +22,6 @@ class AindDynamicForagingTaskParameters(TaskParameters):
     and numerical updaters for dynamic parameter modification.
     """
 
-    reward_size: RewardSize = Field(
-        default=RewardSize(left_value_volume=3, right_value_volume=3), description="Parameters describing reward size."
-    )
     trial_generator: TrialGeneratorSpec = Field(
         default=IntegrationTestTrialGeneratorSpec(),
         description="Trial generator model for generating trials in the task.",

--- a/src/aind_behavior_dynamic_foraging/task_logic/interventions/bias_intervention.py
+++ b/src/aind_behavior_dynamic_foraging/task_logic/interventions/bias_intervention.py
@@ -23,6 +23,12 @@ class BiasInterventionParameters(BaseModel):
         ge=0,
         description="Distance (mm) to move the stage spouts by. This is a relative distance to the current value, not absolute.",
     )
+    reward_fraction: float = Field(
+        default=0.8,
+        ge=0,
+        le=1,
+        description="Fraction of full reward volume delivered for water intervention (0=none, 1=full).",
+    )
 
 
 class BiasIntervention:

--- a/src/aind_behavior_dynamic_foraging/task_logic/trial_generators/block_based_trial_generator.py
+++ b/src/aind_behavior_dynamic_foraging/task_logic/trial_generators/block_based_trial_generator.py
@@ -18,7 +18,7 @@ from aind_behavior_dynamic_foraging.task_logic.interventions.bias_intervention i
 )
 from aind_behavior_dynamic_foraging.task_logic.utils.calculate_bias import calculate_bias
 
-from ..trial_models import Metadata, Trial, TrialMetrics
+from ..trial_models import Metadata, RewardSize, Trial, TrialMetrics
 from ._base import BaseTrialGeneratorSpecModel, ITrialGenerator, TrialOutcome
 
 logger = logging.getLogger(__name__)
@@ -52,16 +52,11 @@ class Block(BaseModel):
     left_length: int = Field(ge=0, description="Minimum number of trials in block.")
 
 
-class RewardSize(BaseModel):
-    right: float = Field(title="Right reward size (uL)")
-    left: float = Field(title="Left reward size (uL)")
-
-
 class BlockBasedTrialGeneratorSpec(BaseTrialGeneratorSpecModel):
     type: Literal["BlockBasedTrialGenerator"] = "BlockBasedTrialGenerator"
 
     reward_size: RewardSize = Field(
-        default=RewardSize(left=3, right=3), description="Parameters describing reward size."
+        default=RewardSize(left=2, right=2), description="Parameters describing reward size."
     )
 
     quiescent_duration: Distribution = Field(
@@ -204,12 +199,12 @@ class BlockBasedTrialGenerator(ITrialGenerator, ABC):
             logger.debug("Right baited: %s" % self.is_right_baited)
 
         is_auto_reward_right = None
-        reward_frac = 1
+        reward_fraction = 1
 
         # determine autowater
         if is_autowater := self._are_autowater_conditions_met():
             is_auto_reward_right = True if self.block.p_right_reward > self.block.p_left_reward else False
-            reward_frac = self.spec.autowater_parameters.reward_fraction
+            reward_fraction = self.spec.autowater_parameters.reward_fraction
             logger.debug("Delivering autowater: is_auto_reward_right = %s" % is_auto_reward_right)
 
         # determine bias correction. Overrides autowater
@@ -218,15 +213,15 @@ class BlockBasedTrialGenerator(ITrialGenerator, ABC):
             is_auto_reward_right, lickspout_offset_delta = self.bias_intervention.determine_antibias_intervention(
                 self.bias
             )
-            reward_frac = 1 if is_auto_reward_right is None else self.spec.bias_intervention_parameters.reward_fraction
+            reward_fraction = (
+                1 if is_auto_reward_right is None else self.spec.bias_intervention_parameters.reward_fraction
+            )
             logger.debug(
                 "Performing bias intervention: is_auto_reward_right = %s, lickspout_offset_delta = %s."
                 % (is_auto_reward_right, lickspout_offset_delta)
             )
 
         return Trial(
-            reward_size_left=self.spec.reward_size.left * reward_frac,
-            reward_size_right=self.spec.reward_size.right * reward_frac,
             p_reward_left=1 if (self.is_left_baited or is_auto_reward_right is False) else self.block.p_left_reward,
             p_reward_right=1 if (self.is_right_baited or is_auto_reward_right) else self.block.p_right_reward,
             reward_consumption_duration=self.spec.reward_consumption_duration,
@@ -235,6 +230,9 @@ class BlockBasedTrialGenerator(ITrialGenerator, ABC):
             inter_trial_interval_duration=iti,
             lickspout_offset_delta=lickspout_offset_delta,
             is_auto_reward_right=is_auto_reward_right,
+            reward_size=RewardSize(
+                left=self.spec.reward_size.left * reward_fraction, right=self.spec.reward_size.right * reward_fraction
+            ),
             metadata=Metadata(
                 p_reward_left=self.block.p_left_reward,
                 p_reward_right=self.block.p_right_reward,

--- a/src/aind_behavior_dynamic_foraging/task_logic/trial_generators/block_based_trial_generator.py
+++ b/src/aind_behavior_dynamic_foraging/task_logic/trial_generators/block_based_trial_generator.py
@@ -42,7 +42,7 @@ class AutoWaterParameters(BaseModel):
         ge=0,
         le=1,
         description="Fraction of full reward volume delivered during auto water (0=none, 1=full).",
-    )  # TODO: Not implemented yet
+    )
 
 
 class Block(BaseModel):
@@ -52,8 +52,17 @@ class Block(BaseModel):
     left_length: int = Field(ge=0, description="Minimum number of trials in block.")
 
 
+class RewardSize(BaseModel):
+    right: float = Field(title="Right reward size (uL)")
+    left: float = Field(title="Left reward size (uL)")
+
+
 class BlockBasedTrialGeneratorSpec(BaseTrialGeneratorSpecModel):
     type: Literal["BlockBasedTrialGenerator"] = "BlockBasedTrialGenerator"
+
+    reward_size: RewardSize = Field(
+        default=RewardSize(left=3, right=3), description="Parameters describing reward size."
+    )
 
     quiescent_duration: Distribution = Field(
         default=ExponentialDistribution(
@@ -195,10 +204,12 @@ class BlockBasedTrialGenerator(ITrialGenerator, ABC):
             logger.debug("Right baited: %s" % self.is_right_baited)
 
         is_auto_reward_right = None
+        reward_frac = 1
 
         # determine autowater
         if is_autowater := self._are_autowater_conditions_met():
             is_auto_reward_right = True if self.block.p_right_reward > self.block.p_left_reward else False
+            reward_frac = self.spec.autowater_parameters.reward_fraction
             logger.debug("Delivering autowater: is_auto_reward_right = %s" % is_auto_reward_right)
 
         # determine bias correction. Overrides autowater
@@ -207,12 +218,15 @@ class BlockBasedTrialGenerator(ITrialGenerator, ABC):
             is_auto_reward_right, lickspout_offset_delta = self.bias_intervention.determine_antibias_intervention(
                 self.bias
             )
+            reward_frac = 1 if is_auto_reward_right is None else self.spec.bias_intervention_parameters.reward_fraction
             logger.debug(
                 "Performing bias intervention: is_auto_reward_right = %s, lickspout_offset_delta = %s."
                 % (is_auto_reward_right, lickspout_offset_delta)
             )
 
         return Trial(
+            reward_size_left=self.spec.reward_size.left * reward_frac,
+            reward_size_right=self.spec.reward_size.right * reward_frac,
             p_reward_left=1 if (self.is_left_baited or is_auto_reward_right is False) else self.block.p_left_reward,
             p_reward_right=1 if (self.is_right_baited or is_auto_reward_right) else self.block.p_right_reward,
             reward_consumption_duration=self.spec.reward_consumption_duration,

--- a/src/aind_behavior_dynamic_foraging/task_logic/trial_models.py
+++ b/src/aind_behavior_dynamic_foraging/task_logic/trial_models.py
@@ -64,12 +64,17 @@ class Metadata(BaseModel):
     )
 
 
+class RewardSize(BaseModel):
+    right: float = Field(gt=0, title="Right reward size (uL)")
+    left: float = Field(gt=0, title="Left reward size (uL)")
+
+
 class Trial(BaseModel):
     """Represents a single trial that can be instantiated by the Bonsai state machine."""
 
-    reward_size_left: float = Field(default=1.0, ge=0, title="Left reward size (uL)")
-
-    reward_size_right: float = Field(default=1.0, ge=0, title="Right reward size (uL)")
+    reward_size: RewardSize = Field(
+        default=RewardSize(left=2.0, right=2.0), description="Parameters describing reward size."
+    )
 
     p_reward_left: float = Field(
         default=1.0, ge=0, le=1, description="The probability of reward on the left side if response is made."

--- a/src/aind_behavior_dynamic_foraging/task_logic/trial_models.py
+++ b/src/aind_behavior_dynamic_foraging/task_logic/trial_models.py
@@ -67,6 +67,10 @@ class Metadata(BaseModel):
 class Trial(BaseModel):
     """Represents a single trial that can be instantiated by the Bonsai state machine."""
 
+    reward_size_left: float = Field(default=1.0, ge=0, title="Left reward size (uL)")
+
+    reward_size_right: float = Field(default=1.0, ge=0, title="Right reward size (uL)")
+
     p_reward_left: float = Field(
         default=1.0, ge=0, le=1, description="The probability of reward on the left side if response is made."
     )

--- a/src/main.bonsai
+++ b/src/main.bonsai
@@ -208,6 +208,18 @@
             <Expression xsi:type="rx:BehaviorSubject">
               <Name>ExperimentState</Name>
             </Expression>
+            <Expression xsi:type="Annotation">
+              <Name>Default size</Name>
+              <Text><![CDATA[Volume will be set per trial basis based on trial generator spec]]></Text>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="DoubleProperty">
+                <Value>2</Value>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="rx:BehaviorSubject">
+              <Name>DefaultRewardSize</Name>
+            </Expression>
             <Expression xsi:type="SubscribeSubject">
               <Name>SetIsRightRewardAmount</Name>
             </Expression>
@@ -222,13 +234,7 @@
               </Combinator>
             </Expression>
             <Expression xsi:type="SubscribeSubject">
-              <Name>TaskLogicParameters</Name>
-            </Expression>
-            <Expression xsi:type="MemberSelector">
-              <Selector>RewardSize</Selector>
-            </Expression>
-            <Expression xsi:type="MemberSelector">
-              <Selector>RightValueVolume</Selector>
+              <Name>DefaultRewardSize</Name>
             </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="rx:Zip" />
@@ -247,13 +253,7 @@
               </Combinator>
             </Expression>
             <Expression xsi:type="SubscribeSubject">
-              <Name>TaskLogicParameters</Name>
-            </Expression>
-            <Expression xsi:type="MemberSelector">
-              <Selector>RewardSize</Selector>
-            </Expression>
-            <Expression xsi:type="MemberSelector">
-              <Selector>LeftValueVolume</Selector>
+              <Name>DefaultRewardSize</Name>
             </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="rx:Zip" />
@@ -300,20 +300,18 @@
             <Edge From="29" To="30" Label="Source1" />
             <Edge From="31" To="32" Label="Source1" />
             <Edge From="32" To="33" Label="Source1" />
-            <Edge From="33" To="37" Label="Source1" />
             <Edge From="34" To="35" Label="Source1" />
             <Edge From="35" To="36" Label="Source1" />
-            <Edge From="36" To="37" Label="Source2" />
-            <Edge From="38" To="39" Label="Source1" />
+            <Edge From="36" To="38" Label="Source1" />
+            <Edge From="37" To="38" Label="Source2" />
             <Edge From="39" To="40" Label="Source1" />
-            <Edge From="40" To="44" Label="Source1" />
-            <Edge From="41" To="42" Label="Source1" />
-            <Edge From="42" To="43" Label="Source1" />
-            <Edge From="43" To="44" Label="Source2" />
-            <Edge From="45" To="47" Label="Source1" />
-            <Edge From="46" To="47" Label="Source2" />
+            <Edge From="40" To="41" Label="Source1" />
+            <Edge From="41" To="43" Label="Source1" />
+            <Edge From="42" To="43" Label="Source2" />
+            <Edge From="44" To="46" Label="Source1" />
+            <Edge From="45" To="46" Label="Source2" />
+            <Edge From="46" To="47" Label="Source1" />
             <Edge From="47" To="48" Label="Source1" />
-            <Edge From="48" To="49" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>

--- a/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/coupled_baiting/stages.py
+++ b/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/coupled_baiting/stages.py
@@ -2,12 +2,14 @@ from aind_behavior_curriculum import MetricsProvider, Stage
 from aind_behavior_dynamic_foraging.task_logic import (
     AindDynamicForagingTaskLogic,
     AindDynamicForagingTaskParameters,
-    RewardSize,
 )
 from aind_behavior_dynamic_foraging.task_logic.trial_generators import (
     CoupledTrialGeneratorSpec,
     CoupledWarmupTrialGeneratorSpec,
     TrialGeneratorCompositeSpec,
+)
+from aind_behavior_dynamic_foraging.task_logic.trial_generators.block_based_trial_generator import (
+    RewardSize,
 )
 from aind_behavior_dynamic_foraging.task_logic.trial_generators.coupled_trial_generators.base_coupled_trial_generator import (
     RewardProbabilityParameters,
@@ -35,10 +37,10 @@ def make_s_stage_1_warmup():
         name="stage_1_warmup",
         task=AindDynamicForagingTaskLogic(
             task_parameters=AindDynamicForagingTaskParameters(
-                reward_size=RewardSize(right_value_volume=4.0, left_value_volume=4.0),
                 trial_generator=TrialGeneratorCompositeSpec(
                     generators=[
                         CoupledWarmupTrialGeneratorSpec(
+                            reward_size=RewardSize(right=4.0, left=4.0),
                             reward_probability_parameters=RewardProbabilityParameters(
                                 base_reward_sum=1, reward_pairs=[[1.0, 0.0]]
                             ),
@@ -53,6 +55,7 @@ def make_s_stage_1_warmup():
                             reward_consumption_duration=1.0,
                         ),
                         CoupledTrialGeneratorSpec(
+                            reward_size=RewardSize(right=4.0, left=4.0),
                             trial_generation_end_parameters=CoupledTrialGenerationEndConditions(
                                 max_trial=1000,
                                 max_time=4500,
@@ -97,8 +100,8 @@ def make_s_stage_1():
         name="stage_1",
         task=AindDynamicForagingTaskLogic(
             task_parameters=AindDynamicForagingTaskParameters(
-                reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=CoupledTrialGeneratorSpec(
+                    reward_size=RewardSize(right=2.0, left=2.0),
                     trial_generation_end_parameters=CoupledTrialGenerationEndConditions(
                         max_trial=1000,
                         max_time=4500,
@@ -141,8 +144,8 @@ def make_s_stage_2():
         name="stage_2",
         task=AindDynamicForagingTaskLogic(
             task_parameters=AindDynamicForagingTaskParameters(
-                reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=CoupledTrialGeneratorSpec(
+                    reward_size=RewardSize(right=2.0, left=2.0),
                     trial_generation_end_parameters=CoupledTrialGenerationEndConditions(
                         max_trial=1000,
                         max_time=4500,
@@ -185,8 +188,8 @@ def make_s_stage_3():
         name="stage_3",
         task=AindDynamicForagingTaskLogic(
             task_parameters=AindDynamicForagingTaskParameters(
-                reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=CoupledTrialGeneratorSpec(
+                    reward_size=RewardSize(right=2.0, left=2.0),
                     trial_generation_end_parameters=CoupledTrialGenerationEndConditions(
                         max_trial=1000,
                         max_time=4500,
@@ -229,8 +232,8 @@ def make_s_stage_final():
         name="final",
         task=AindDynamicForagingTaskLogic(
             task_parameters=AindDynamicForagingTaskParameters(
-                reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=CoupledTrialGeneratorSpec(
+                    reward_size=RewardSize(right=2.0, left=2.0),
                     trial_generation_end_parameters=CoupledTrialGenerationEndConditions(
                         max_trial=1000,
                         max_time=4500,
@@ -269,8 +272,8 @@ def make_s_stage_graduated():
         name="graduated",
         task=AindDynamicForagingTaskLogic(
             task_parameters=AindDynamicForagingTaskParameters(
-                reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=CoupledTrialGeneratorSpec(
+                    reward_size=RewardSize(right=2.0, left=2.0),
                     trial_generation_end_parameters=CoupledTrialGenerationEndConditions(
                         max_trial=1000,
                         max_time=4500,

--- a/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/coupled_baiting/stages.py
+++ b/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/coupled_baiting/stages.py
@@ -9,8 +9,8 @@ from aind_behavior_dynamic_foraging.task_logic.trial_generators import (
     TrialGeneratorCompositeSpec,
 )
 from aind_behavior_dynamic_foraging.task_logic.trial_generators.block_based_trial_generator import (
-    RewardSize,
     AutoWaterParameters,
+    RewardSize,
 )
 from aind_behavior_dynamic_foraging.task_logic.trial_generators.coupled_trial_generators.base_coupled_trial_generator import (
     RewardProbabilityParameters,

--- a/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/uncoupled/stages.py
+++ b/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/uncoupled/stages.py
@@ -2,7 +2,6 @@ from aind_behavior_curriculum import MetricsProvider, Stage
 from aind_behavior_dynamic_foraging.task_logic import (
     AindDynamicForagingTaskLogic,
     AindDynamicForagingTaskParameters,
-    RewardSize,
 )
 from aind_behavior_dynamic_foraging.task_logic.trial_generators import (
     CoupledTrialGeneratorSpec,
@@ -11,6 +10,7 @@ from aind_behavior_dynamic_foraging.task_logic.trial_generators import (
 )
 from aind_behavior_dynamic_foraging.task_logic.trial_generators.block_based_trial_generator import (
     AutoWaterParameters,
+    RewardSize,
 )
 from aind_behavior_dynamic_foraging.task_logic.trial_generators.coupled_trial_generators.base_coupled_trial_generator import (
     RewardProbabilityParameters,
@@ -47,10 +47,10 @@ def make_s_stage_1_warmup():
         name="stage_1_warmup",
         task=AindDynamicForagingTaskLogic(
             task_parameters=AindDynamicForagingTaskParameters(
-                reward_size=RewardSize(right_value_volume=4.0, left_value_volume=4.0),
                 trial_generator=TrialGeneratorCompositeSpec(
                     generators=[
                         CoupledWarmupTrialGeneratorSpec(
+                            reward_size=RewardSize(right=4.0, left=4.0),
                             autowater_parameters=AutoWaterParameters(
                                 reward_fraction=0.5, min_ignored_trials=3, min_unrewarded_trials=3
                             ),
@@ -74,6 +74,7 @@ def make_s_stage_1_warmup():
                             reward_consumption_duration=1.0,
                         ),
                         CoupledTrialGeneratorSpec(
+                            reward_size=RewardSize(right=4.0, left=4.0),
                             autowater_parameters=AutoWaterParameters(
                                 reward_fraction=0.5, min_ignored_trials=3, min_unrewarded_trials=3
                             ),
@@ -121,8 +122,8 @@ def make_s_stage_1():
         name="stage_1",
         task=AindDynamicForagingTaskLogic(
             task_parameters=AindDynamicForagingTaskParameters(
-                reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=CoupledTrialGeneratorSpec(
+                    reward_size=RewardSize(right=2.0, left=2.0),
                     autowater_parameters=AutoWaterParameters(
                         reward_fraction=0.5, min_ignored_trials=5, min_unrewarded_trials=5
                     ),
@@ -168,8 +169,8 @@ def make_s_stage_2():
         name="stage_2",
         task=AindDynamicForagingTaskLogic(
             task_parameters=AindDynamicForagingTaskParameters(
-                reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=CoupledTrialGeneratorSpec(
+                    reward_size=RewardSize(right=2.0, left=2.0),
                     autowater_parameters=AutoWaterParameters(
                         reward_fraction=0.5, min_ignored_trials=7, min_unrewarded_trials=7
                     ),
@@ -215,8 +216,8 @@ def make_s_stage_3():
         name="stage_3",
         task=AindDynamicForagingTaskLogic(
             task_parameters=AindDynamicForagingTaskParameters(
-                reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=UncoupledTrialGeneratorSpec(
+                    reward_size=RewardSize(right=2.0, left=2.0),
                     autowater_parameters=AutoWaterParameters(
                         reward_fraction=0.5, min_ignored_trials=10, min_unrewarded_trials=10
                     ),
@@ -251,8 +252,8 @@ def make_s_stage_final():
         name="final",
         task=AindDynamicForagingTaskLogic(
             task_parameters=AindDynamicForagingTaskParameters(
-                reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=UncoupledTrialGeneratorSpec(
+                    reward_size=RewardSize(right=2.0, left=2.0),
                     trial_generation_end_parameters=UncoupledTrialGenerationEndConditions(
                         max_trial=1000,
                         max_time=4500,
@@ -285,8 +286,8 @@ def make_s_stage_graduated():
         name="graduated",
         task=AindDynamicForagingTaskLogic(
             task_parameters=AindDynamicForagingTaskParameters(
-                reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=UncoupledTrialGeneratorSpec(
+                    reward_size=RewardSize(right=2.0, left=2.0),
                     autowater_parameters=None,
                     trial_generation_end_parameters=UncoupledTrialGenerationEndConditions(
                         max_trial=1000,

--- a/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/uncoupled_baiting/stages.py
+++ b/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/uncoupled_baiting/stages.py
@@ -2,12 +2,14 @@ from aind_behavior_curriculum import MetricsProvider, Stage
 from aind_behavior_dynamic_foraging.task_logic import (
     AindDynamicForagingTaskLogic,
     AindDynamicForagingTaskParameters,
-    RewardSize,
 )
 from aind_behavior_dynamic_foraging.task_logic.trial_generators import (
     CoupledTrialGeneratorSpec,
     CoupledWarmupTrialGeneratorSpec,
     TrialGeneratorCompositeSpec,
+)
+from aind_behavior_dynamic_foraging.task_logic.trial_generators.block_based_trial_generator import (
+    RewardSize,
 )
 from aind_behavior_dynamic_foraging.task_logic.trial_generators.coupled_trial_generators.base_coupled_trial_generator import (
     RewardProbabilityParameters,
@@ -44,10 +46,10 @@ def make_s_stage_1_warmup():
         name="stage_1_warmup",
         task=AindDynamicForagingTaskLogic(
             task_parameters=AindDynamicForagingTaskParameters(
-                reward_size=RewardSize(right_value_volume=4.0, left_value_volume=4.0),
                 trial_generator=TrialGeneratorCompositeSpec(
                     generators=[
                         CoupledWarmupTrialGeneratorSpec(
+                            reward_size=RewardSize(right=4.0, left=4.0),
                             trial_generation_end_parameters=CoupledWarmupTrialGenerationEndConditions(
                                 min_trial=50,
                                 max_choice_bias=0.1,
@@ -68,6 +70,7 @@ def make_s_stage_1_warmup():
                             reward_consumption_duration=1.0,
                         ),
                         CoupledTrialGeneratorSpec(
+                            reward_size=RewardSize(right=4.0, left=4.0),
                             trial_generation_end_parameters=CoupledTrialGenerationEndConditions(
                                 max_trial=1000,
                                 max_time=4500,
@@ -112,8 +115,8 @@ def make_s_stage_1():
         name="stage_1",
         task=AindDynamicForagingTaskLogic(
             task_parameters=AindDynamicForagingTaskParameters(
-                reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=CoupledTrialGeneratorSpec(
+                    reward_size=RewardSize(right=2.0, left=2.0),
                     trial_generation_end_parameters=CoupledTrialGenerationEndConditions(
                         max_trial=1000,
                         max_time=4500,
@@ -156,8 +159,8 @@ def make_s_stage_2():
         name="stage_2",
         task=AindDynamicForagingTaskLogic(
             task_parameters=AindDynamicForagingTaskParameters(
-                reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=CoupledTrialGeneratorSpec(
+                    reward_size=RewardSize(right=2.0, left=2.0),
                     trial_generation_end_parameters=CoupledTrialGenerationEndConditions(
                         max_trial=1000,
                         max_time=4500,
@@ -200,8 +203,8 @@ def make_s_stage_3():
         name="stage_3",
         task=AindDynamicForagingTaskLogic(
             task_parameters=AindDynamicForagingTaskParameters(
-                reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=UncoupledTrialGeneratorSpec(
+                    reward_size=RewardSize(right=2.0, left=2.0),
                     trial_generation_end_parameters=UncoupledTrialGenerationEndConditions(
                         max_trial=1000,
                         max_time=4500,
@@ -233,8 +236,8 @@ def make_s_stage_final():
         name="final",
         task=AindDynamicForagingTaskLogic(
             task_parameters=AindDynamicForagingTaskParameters(
-                reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=UncoupledTrialGeneratorSpec(
+                    reward_size=RewardSize(right=2.0, left=2.0),
                     trial_generation_end_parameters=UncoupledTrialGenerationEndConditions(
                         max_trial=1000,
                         max_time=4500,
@@ -266,8 +269,8 @@ def make_s_stage_graduated():
         name="graduated",
         task=AindDynamicForagingTaskLogic(
             task_parameters=AindDynamicForagingTaskParameters(
-                reward_size=RewardSize(right_value_volume=2.0, left_value_volume=2.0),
                 trial_generator=UncoupledTrialGeneratorSpec(
+                    reward_size=RewardSize(right=2.0, left=2.0),
                     trial_generation_end_parameters=UncoupledTrialGenerationEndConditions(
                         max_trial=1000,
                         max_time=4500,

--- a/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/uncoupled_baiting/stages.py
+++ b/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/uncoupled_baiting/stages.py
@@ -9,8 +9,8 @@ from aind_behavior_dynamic_foraging.task_logic.trial_generators import (
     TrialGeneratorCompositeSpec,
 )
 from aind_behavior_dynamic_foraging.task_logic.trial_generators.block_based_trial_generator import (
-    RewardSize,
     AutoWaterParameters,
+    RewardSize,
 )
 from aind_behavior_dynamic_foraging.task_logic.trial_generators.coupled_trial_generators.base_coupled_trial_generator import (
     RewardProbabilityParameters,


### PR DESCRIPTION
Move reward size form task logic level to trial level. Allows to give fraction of reward for auto reward. Closes #85 

At bonsai level, default reward is set to 2ul at initialization and during session, reward size is updated in calculate reward block 