### PR TITLE
Add curriculum to metadata

### DIFF
--- a/schema/coupled_baiting.json
+++ b/schema/coupled_baiting.json
@@ -1,7 +1,7 @@
 {
     "pkg_location": "aind_behavior_dynamic_foraging_curricula.coupled_baiting",
-    "name": "CoupledBaiting",
-    "version": "0.0.2",
+    "name": "Coupled Baiting",
+    "version": "0.0.3",
     "graph": {
         "nodes": {
             "0": {

--- a/schema/uncoupled.json
+++ b/schema/uncoupled.json
@@ -1,7 +1,7 @@
 {
     "pkg_location": "aind_behavior_dynamic_foraging_curricula.uncoupled",
-    "name": "Uncoupled",
-    "version": "0.0.2",
+    "name": "Uncoupled Without Baiting",
+    "version": "0.0.3",
     "graph": {
         "nodes": {
             "0": {

--- a/schema/uncoupled_baiting.json
+++ b/schema/uncoupled_baiting.json
@@ -1,7 +1,7 @@
 {
     "pkg_location": "aind_behavior_dynamic_foraging_curricula.uncoupled_baiting",
-    "name": "UncoupledBaiting",
-    "version": "0.0.2",
+    "name": "Uncoupled Baiting",
+    "version": "0.0.3",
     "graph": {
         "nodes": {
             "0": {

--- a/uv.lock
+++ b/uv.lock
@@ -105,7 +105,7 @@ docs = [
 
 [[package]]
 name = "aind-behavior-dynamic-foraging-curricula"
-version = "0.0.2"
+version = "0.0.3"
 source = { editable = "workspace/aind_behavior_dynamic_foraging_curricula" }
 dependencies = [
     { name = "aind-behavior-curriculum" },

--- a/workspace/aind_behavior_dynamic_foraging_curricula/pyproject.toml
+++ b/workspace/aind_behavior_dynamic_foraging_curricula/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     {name = "Micah Woodard", email = "micah.woodard@alleninstitute.org"}
     ]
 license = "MIT"
-version = "0.0.2"
+version = "0.0.3"
 requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3.11",

--- a/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/coupled_baiting/curriculum.py
+++ b/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/coupled_baiting/curriculum.py
@@ -20,7 +20,7 @@ from .stages import (
     make_s_stage_graduated,
 )
 
-CURRICULUM_NAME = "CoupledBaiting"
+CURRICULUM_NAME = "Coupled Baiting"
 PKG_LOCATION = ".".join(__name__.split(".")[:-1])
 
 TModel = TypeVar("TModel", bound=pydantic.BaseModel)

--- a/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/uncoupled/curriculum.py
+++ b/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/uncoupled/curriculum.py
@@ -20,7 +20,7 @@ from .stages import (
     make_s_stage_graduated,
 )
 
-CURRICULUM_NAME = "Uncoupled"
+CURRICULUM_NAME = "Uncoupled Without Baiting"
 PKG_LOCATION = ".".join(__name__.split(".")[:-1])
 
 TModel = TypeVar("TModel", bound=pydantic.BaseModel)

--- a/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/uncoupled_baiting/curriculum.py
+++ b/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/uncoupled_baiting/curriculum.py
@@ -20,7 +20,7 @@ from .stages import (
     make_s_stage_graduated,
 )
 
-CURRICULUM_NAME = "UncoupledBaiting"
+CURRICULUM_NAME = "Uncoupled Baiting"
 PKG_LOCATION = ".".join(__name__.split(".")[:-1])
 
 TModel = TypeVar("TModel", bound=pydantic.BaseModel)

--- a/workspace/aind_behavior_dynamic_foraging_metadata_mapper/src/aind_behavior_dynamic_foraging_metadata_mapper/acquisition.py
+++ b/workspace/aind_behavior_dynamic_foraging_metadata_mapper/src/aind_behavior_dynamic_foraging_metadata_mapper/acquisition.py
@@ -110,7 +110,11 @@ class AindAcquisitionDataMapper(AindDataSchemaSessionDataMapper):
         rig_model = AindDynamicForagingRig.model_validate(input_schemas["Rig"].data)
         task_logic_model = AindDynamicForagingTaskLogic.model_validate(input_schemas["TaskLogic"].data)
         repository = git.Repo(self.repository_path)
-        curriculum_repository = git.Repo(self.curriculum_repository_path or self.repository_path)
+        curriculum_repository = _resolve_curriculum_repository(
+            repository,
+            self.curriculum_repository_path,
+            self.repository_path,
+        )
         trainer_state = TrainerState.model_validate(dataset["Behavior"]["TrainerState"].data)
 
         if self.session_end_time is None:
@@ -187,6 +191,29 @@ class AindAcquisitionDataMapper(AindDataSchemaSessionDataMapper):
             data_streams=data_streams,
             stimulus_epochs=[stimulus_epoch],
         )
+
+
+def _resolve_curriculum_repository(
+    repository: git.Repo,
+    curriculum_repository_path: Optional[os.PathLike],
+    repository_path: os.PathLike,
+) -> git.Repo:
+    """Resolve the curriculum repository, preferring a matching main-repo submodule."""
+    if not curriculum_repository_path:
+        return repository
+
+    curriculum_path = Path(curriculum_repository_path).resolve()
+    repository_root = Path(repository.working_tree_dir or repository_path).resolve()
+    submodule_paths = {(repository_root / submodule.path).resolve(): submodule for submodule in repository.submodules}
+
+    if curriculum_path in submodule_paths:
+        return submodule_paths[curriculum_path].module()
+
+    logger.info(
+        "Curriculum repository path is not a submodule of the main repository: %s",
+        curriculum_path,
+    )
+    return git.Repo(curriculum_path)
 
 
 def _get_subject_details(data_path: os.PathLike) -> AcquisitionSubjectDetails:

--- a/workspace/aind_behavior_dynamic_foraging_metadata_mapper/src/aind_behavior_dynamic_foraging_metadata_mapper/acquisition.py
+++ b/workspace/aind_behavior_dynamic_foraging_metadata_mapper/src/aind_behavior_dynamic_foraging_metadata_mapper/acquisition.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Optional
 
 import git
+from aind_behavior_curriculum import TrainerState
 from aind_behavior_dynamic_foraging.data_contract import dataset as df_foraging_dataset
 from aind_behavior_dynamic_foraging.data_contract.utils import calculate_consumed_water
 from aind_behavior_dynamic_foraging.rig import AindDynamicForagingRig
@@ -38,7 +39,11 @@ logger = logging.getLogger(__name__)
 
 class AindAcquisitionDataMapper(AindDataSchemaSessionDataMapper):
     def __init__(
-        self, data_path: os.PathLike, repository_path: os.PathLike, session_end_time: Optional[datetime] = None
+        self,
+        data_path: os.PathLike,
+        repository_path: os.PathLike,
+        session_end_time: Optional[datetime] = None,
+        curriculum_repository_path: Optional[os.PathLike] = None,
     ):
         """
         Class to create acquisition model for completed session.
@@ -58,6 +63,7 @@ class AindAcquisitionDataMapper(AindDataSchemaSessionDataMapper):
         self.data_path = data_path
         self.repository_path = repository_path
         self.session_end_time = session_end_time
+        self.curriculum_repository_path = curriculum_repository_path
 
         self.session_model = model_from_json_file(
             json_path=Path(self.data_path) / "behavior" / "Logs" / "session_output.json", model=Session
@@ -104,13 +110,18 @@ class AindAcquisitionDataMapper(AindDataSchemaSessionDataMapper):
         rig_model = AindDynamicForagingRig.model_validate(input_schemas["Rig"].data)
         task_logic_model = AindDynamicForagingTaskLogic.model_validate(input_schemas["TaskLogic"].data)
         repository = git.Repo(self.repository_path)
+        curriculum_repository = git.Repo(self.curriculum_repository_path or self.repository_path)
+        trainer_state = TrainerState.model_validate(dataset["Behavior"]["TrainerState"].data)
 
         if self.session_end_time is None:
             logger.warning("Session end time is not set. Using current time as end time.")
             acquisition_end_time = datetime.now(tz=timezone.utc)
+        else:
+            acquisition_end_time = self.session_end_time
 
         bonsai_code = _get_bonsai_as_code(repository)
         python_code = _get_python_as_code(repository)
+        curriculum_code = _get_curriculum_as_code(curriculum_repository, trainer_state)
 
         cameras = data_mapper_helpers.get_cameras(rig_model, exclude_without_video_writer=True)
         camera_configs = [_get_camera_config(k, v, repository) for k, v in cameras.items()]
@@ -131,7 +142,7 @@ class AindAcquisitionDataMapper(AindDataSchemaSessionDataMapper):
             DataStream(
                 stream_start_time=session_model.date,
                 stream_end_time=acquisition_end_time,
-                code=[bonsai_code, python_code],
+                code=[bonsai_code, python_code, curriculum_code],
                 active_devices=active_devices,
                 modalities=modalities,
                 configurations=camera_configs,
@@ -141,7 +152,6 @@ class AindAcquisitionDataMapper(AindDataSchemaSessionDataMapper):
 
         # populate behavior epoch
         metrics = dataset["Behavior"]["Metrics"].data
-        trainer_state = dataset["Behavior"]["TrainerState"].data
         trial_outcomes = dataset["Behavior"]["SoftwareEvents"]["TrialOutcome"].data["data"].iloc
         rewarded = sum(to["is_rewarded"] for to in trial_outcomes)
         water = calculate_consumed_water(self.data_path)
@@ -161,7 +171,7 @@ class AindAcquisitionDataMapper(AindDataSchemaSessionDataMapper):
             code=bonsai_code,
             stimulus_modalities=[StimulusModality.AUDITORY],
             performance_metrics=performance_metrics,
-            curriculum_status=trainer_state.stage.name,
+            training_protocol_name=str(trainer_state.curriculum.name),
         )
 
         # Construct aind-data-schema session
@@ -209,6 +219,17 @@ def _get_camera_config(name: str, camera: abs_camera.CameraTypes, repository: gi
         exposure_time_unit=units.TimeUnit.US,
         trigger_type=TriggerType.EXTERNAL,
         compression=compression,
+    )
+
+
+def _get_curriculum_as_code(repository: git.Repo, trainer_state: TrainerState) -> Code:
+
+    return Code(
+        url=repository.remote().url,
+        commit_hash=repository.head.commit.hexsha,
+        name=trainer_state.curriculum.pkg_location,
+        version=trainer_state.curriculum.version,
+        language="aind-behavior-curriculum",
     )
 
 

--- a/workspace/aind_behavior_dynamic_foraging_metadata_mapper/src/aind_behavior_dynamic_foraging_metadata_mapper/acquisition.py
+++ b/workspace/aind_behavior_dynamic_foraging_metadata_mapper/src/aind_behavior_dynamic_foraging_metadata_mapper/acquisition.py
@@ -43,7 +43,6 @@ class AindAcquisitionDataMapper(AindDataSchemaSessionDataMapper):
         data_path: os.PathLike,
         repository_path: os.PathLike,
         session_end_time: Optional[datetime] = None,
-        curriculum_repository_path: Optional[os.PathLike] = None,
     ):
         """
         Class to create acquisition model for completed session.
@@ -63,7 +62,6 @@ class AindAcquisitionDataMapper(AindDataSchemaSessionDataMapper):
         self.data_path = data_path
         self.repository_path = repository_path
         self.session_end_time = session_end_time
-        self.curriculum_repository_path = curriculum_repository_path
 
         self.session_model = model_from_json_file(
             json_path=Path(self.data_path) / "behavior" / "Logs" / "session_output.json", model=Session
@@ -110,11 +108,6 @@ class AindAcquisitionDataMapper(AindDataSchemaSessionDataMapper):
         rig_model = AindDynamicForagingRig.model_validate(input_schemas["Rig"].data)
         task_logic_model = AindDynamicForagingTaskLogic.model_validate(input_schemas["TaskLogic"].data)
         repository = git.Repo(self.repository_path)
-        curriculum_repository = _resolve_curriculum_repository(
-            repository,
-            self.curriculum_repository_path,
-            self.repository_path,
-        )
         trainer_state = TrainerState.model_validate(dataset["Behavior"]["TrainerState"].data)
 
         if self.session_end_time is None:
@@ -125,7 +118,7 @@ class AindAcquisitionDataMapper(AindDataSchemaSessionDataMapper):
 
         bonsai_code = _get_bonsai_as_code(repository)
         python_code = _get_python_as_code(repository)
-        curriculum_code = _get_curriculum_as_code(curriculum_repository, trainer_state)
+        curriculum_code = _get_curriculum_as_code(repository, trainer_state)
 
         cameras = data_mapper_helpers.get_cameras(rig_model, exclude_without_video_writer=True)
         camera_configs = [_get_camera_config(k, v, repository) for k, v in cameras.items()]
@@ -191,29 +184,6 @@ class AindAcquisitionDataMapper(AindDataSchemaSessionDataMapper):
             data_streams=data_streams,
             stimulus_epochs=[stimulus_epoch],
         )
-
-
-def _resolve_curriculum_repository(
-    repository: git.Repo,
-    curriculum_repository_path: Optional[os.PathLike],
-    repository_path: os.PathLike,
-) -> git.Repo:
-    """Resolve the curriculum repository, preferring a matching main-repo submodule."""
-    if not curriculum_repository_path:
-        return repository
-
-    curriculum_path = Path(curriculum_repository_path).resolve()
-    repository_root = Path(repository.working_tree_dir or repository_path).resolve()
-    submodule_paths = {(repository_root / submodule.path).resolve(): submodule for submodule in repository.submodules}
-
-    if curriculum_path in submodule_paths:
-        return submodule_paths[curriculum_path].module()
-
-    logger.info(
-        "Curriculum repository path is not a submodule of the main repository: %s",
-        curriculum_path,
-    )
-    return git.Repo(curriculum_path)
 
 
 def _get_subject_details(data_path: os.PathLike) -> AcquisitionSubjectDetails:

--- a/workspace/aind_behavior_dynamic_foraging_metadata_mapper/src/aind_behavior_dynamic_foraging_metadata_mapper/cli.py
+++ b/workspace/aind_behavior_dynamic_foraging_metadata_mapper/src/aind_behavior_dynamic_foraging_metadata_mapper/cli.py
@@ -18,6 +18,10 @@ class DataMapperCli(BaseSettings, cli_kebab_case=True):
         default=None,
         description="End time of the session in ISO format. If not provided, will use the time the data mapping is run.",
     )
+    curriculum_repository_path: t.Optional[os.PathLike] = Field(
+        default=None,
+        description="Path to the curriculum repository. If not provided, will use the repository path.",
+    )
     suffix: t.Optional[str] = Field(default="", description="Suffix to append to the output filenames.")
 
     def cli_cmd(self):

--- a/workspace/aind_behavior_dynamic_foraging_metadata_mapper/src/aind_behavior_dynamic_foraging_metadata_mapper/cli.py
+++ b/workspace/aind_behavior_dynamic_foraging_metadata_mapper/src/aind_behavior_dynamic_foraging_metadata_mapper/cli.py
@@ -18,10 +18,6 @@ class DataMapperCli(BaseSettings, cli_kebab_case=True):
         default=None,
         description="End time of the session in ISO format. If not provided, will use the time the data mapping is run.",
     )
-    curriculum_repository_path: t.Optional[os.PathLike] = Field(
-        default=None,
-        description="Path to the curriculum repository. If not provided, will use the repository path.",
-    )
     suffix: t.Optional[str] = Field(default="", description="Suffix to append to the output filenames.")
 
     def cli_cmd(self):


### PR DESCRIPTION
Attempts to address issues in [#131](https://github.com/AllenNeuralDynamics/DF-Refactoring/issues/131)

- adds curriculum code object to data_stream code list
- set curriculum name as stimulus epoch training_protocol_name
- Removes acquisition.stimulus_epochs.curriculum_status