### PR TITLE
Updates stage names in metrics to fix validation errors

### DIFF
--- a/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/metrics.py
+++ b/workspace/aind_behavior_dynamic_foraging_curricula/src/aind_behavior_dynamic_foraging_curricula/metrics.py
@@ -7,7 +7,7 @@ from aind_behavior_dynamic_foraging.data_contract import dataset as df_foraging_
 from aind_behavior_dynamic_foraging.task_logic.utils.calculate_foraging_efficiency import calculate_foraging_efficiency
 from pydantic import BeforeValidator, Field
 
-STAGE_NAMES = Literal["stage_1_warmup", "stage_1", "stage_2", "stage_3", "final", "graduated"]
+STAGE_NAMES = Literal["STAGE_1_WARMUP", "STAGE_1", "STAGE_2", "STAGE_3", "STAGE_FINAL", "GRADUATED"]
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Validation errors are occurring due to stage names changing in curriculum stages. Should probably in the future have some sort of test or runtime validation 