### PR TITLE
Fix qc suite

### DIFF
--- a/src/Extensions/Hardware.bonsai
+++ b/src/Extensions/Hardware.bonsai
@@ -196,7 +196,7 @@
               <Name>RigSchema</Name>
             </Expression>
             <Expression xsi:type="MemberSelector">
-              <Selector>HarpSniffDetector</Selector>
+              <Selector>HarpEnvironmentSensor</Selector>
             </Expression>
             <Expression xsi:type="IncludeWorkflow" Path="AllenNeuralDynamics.Core:FilterNotNull.bonsai" />
             <Expression xsi:type="Combinator">

--- a/src/aind_behavior_dynamic_foraging/data_qc/suite.py
+++ b/src/aind_behavior_dynamic_foraging/data_qc/suite.py
@@ -68,9 +68,10 @@ def make_qc_runner(dataset: contract.Dataset) -> qc.Runner:
             "HarpEnvironmentSensor",
         )
 
-    _runner.add_suite(
-        qc.harp.HarpLicketySplitTestSuite(dataset["Behavior"]["HarpLickometerRight"]), "HarpLickometerRight"
-    )
+    if rig.harp_lickometer_right is not None:
+        _runner.add_suite(
+            qc.harp.HarpLicketySplitTestSuite(dataset["Behavior"]["HarpLickometerRight"]), "HarpLickometerRight"
+        )
     _runner.add_suite(
         qc.harp.HarpLicketySplitTestSuite(dataset["Behavior"]["HarpLickometerLeft"]), "HarpLickometerLeft"
     )

--- a/src/aind_behavior_dynamic_foraging/data_qc/suite.py
+++ b/src/aind_behavior_dynamic_foraging/data_qc/suite.py
@@ -72,9 +72,10 @@ def make_qc_runner(dataset: contract.Dataset) -> qc.Runner:
         _runner.add_suite(
             qc.harp.HarpLicketySplitTestSuite(dataset["Behavior"]["HarpLickometerRight"]), "HarpLickometerRight"
         )
-    _runner.add_suite(
-        qc.harp.HarpLicketySplitTestSuite(dataset["Behavior"]["HarpLickometerLeft"]), "HarpLickometerLeft"
-    )
+    if rig.harp_lickometer_left is not None:
+        _runner.add_suite(
+            qc.harp.HarpLicketySplitTestSuite(dataset["Behavior"]["HarpLickometerLeft"]), "HarpLickometerLeft"
+        )
 
     # Add camera qc
     for camera in dataset["BehaviorVideos"]:


### PR DESCRIPTION
QC has been failing on Environment sensor and lickety split devices. Made lickety split devices optional and fixed a naming mismatch in bonsai that originally checked if the sniff detector existed to initialize environment sensor. 

fixes issues [#147](https://github.com/AllenNeuralDynamics/DF-Refactoring/issues/147) and [#142](https://github.com/orgs/AllenNeuralDynamics/projects/191/views/9?pane=issue&itemId=227799172&issue=AllenNeuralDynamics%7CDF-Refactoring%7C142)